### PR TITLE
Add student details editing

### DIFF
--- a/app/api/coach/students/route.ts
+++ b/app/api/coach/students/route.ts
@@ -17,6 +17,8 @@ interface CoachStudentSummary {
   name: string
   email: string | null
   phone?: string
+  address?: string
+  location?: string
   totalClasses: number
   nextClass?: Booking
   upcomingClasses: Booking[]
@@ -86,9 +88,11 @@ export async function GET(request: Request) {
 
       return {
         athleteId: first.athleteId,
-        name: first.athleteName,
-        email: first.athleteEmail,
-        phone: first.athletePhone,
+        name: progress?.athleteName || first.athleteName,
+        email: progress?.athleteEmail ?? first.athleteEmail,
+        phone: progress?.athletePhone || first.athletePhone,
+        address: progress?.athleteAddress || '',
+        location: progress?.athleteLocation || '',
         totalClasses: sorted.length,
         nextClass,
         upcomingClasses,
@@ -110,6 +114,8 @@ export async function GET(request: Request) {
       name: progress.athleteName,
       email: progress.athleteEmail,
       phone: progress.athletePhone,
+      address: progress.athleteAddress || '',
+      location: progress.athleteLocation || '',
       totalClasses: 0,
       upcomingClasses: [],
       progress,
@@ -169,9 +175,97 @@ export async function POST(request: Request) {
       name,
       email: email || null,
       ...(phone ? { phone } : {}),
+      address: '',
+      location: '',
       totalClasses: 0,
       progress,
       entries: [],
+    },
+  })
+}
+
+export async function PUT(request: Request) {
+  const verification = await verifyCoach(request)
+  if (verification.error) return verification.error
+
+  const coachId = verification.caller.uid
+  const body = (await request.json()) as {
+    athleteId?: unknown
+    name?: unknown
+    email?: unknown
+    phone?: unknown
+    address?: unknown
+    location?: unknown
+  }
+  const athleteId = typeof body.athleteId === 'string' ? body.athleteId : ''
+  if (!athleteId) {
+    return NextResponse.json({ error: 'Alumno inválido.' }, { status: 400 })
+  }
+
+  const details = sanitizeStudentDetails(body)
+  if (details.name.length < 2) {
+    return NextResponse.json({ error: 'Nombre inválido.' }, { status: 400 })
+  }
+
+  const [bookingSnapshot, existingProgress] = await Promise.all([
+    adminDb
+      .collection('bookings')
+      .where('coachId', '==', coachId)
+      .where('athleteId', '==', athleteId)
+      .get(),
+    adminDb.collection('coachStudentProgress').doc(studentProgressId(coachId, athleteId)).get(),
+  ])
+  const current = existingProgress.data() as StudentProgress | undefined
+
+  if (bookingSnapshot.empty && !current) {
+    return NextResponse.json({ error: 'No autorizado.' }, { status: 403 })
+  }
+
+  const now = Date.now()
+  const id = studentProgressId(coachId, athleteId)
+  const progress: StudentProgress = {
+    id,
+    coachId,
+    athleteId,
+    athleteName: details.name,
+    athleteEmail: details.email || null,
+    athletePhone: details.phone,
+    athleteAddress: details.address,
+    athleteLocation: details.location,
+    level: current?.level || 'Inicial',
+    goal: current?.goal || '',
+    lastNote: current?.lastNote || '',
+    nextFocus: current?.nextFocus || '',
+    coachAssessment: current?.coachAssessment || 1,
+    createdAt: current?.createdAt || now,
+    updatedAt: now,
+  }
+
+  const batch = adminDb.batch()
+  batch.set(adminDb.collection('coachStudentProgress').doc(id), progress, { merge: true })
+  for (const doc of bookingSnapshot.docs) {
+    batch.set(
+      doc.ref,
+      {
+        athleteName: details.name,
+        athleteEmail: details.email || null,
+        athletePhone: details.phone,
+        updatedAt: now,
+      },
+      { merge: true }
+    )
+  }
+  await batch.commit()
+
+  return NextResponse.json({
+    student: {
+      athleteId,
+      name: details.name,
+      email: details.email || null,
+      phone: details.phone,
+      address: details.address,
+      location: details.location,
+      progress,
     },
   })
 }
@@ -240,6 +334,22 @@ export async function PATCH(request: Request) {
   await Promise.all([docRef.set(progress, { merge: true }), entryRef.set(entry)])
 
   return NextResponse.json({ progress, entry })
+}
+
+function sanitizeStudentDetails(input: {
+  name?: unknown
+  email?: unknown
+  phone?: unknown
+  address?: unknown
+  location?: unknown
+}) {
+  return {
+    name: typeof input.name === 'string' ? input.name.trim().slice(0, 120) : '',
+    email: typeof input.email === 'string' ? input.email.trim().slice(0, 160) : '',
+    phone: typeof input.phone === 'string' ? input.phone.trim().slice(0, 40) : '',
+    address: typeof input.address === 'string' ? input.address.trim().slice(0, 240) : '',
+    location: typeof input.location === 'string' ? input.location.trim().slice(0, 500) : '',
+  }
 }
 
 function groupBookingsByAthlete(bookings: Booking[]) {

--- a/components/coach/CoachStudents.tsx
+++ b/components/coach/CoachStudents.tsx
@@ -8,7 +8,11 @@ import { useEffect, useRef, useState } from 'react'
 import {
   FiCalendar,
   FiChevronDown,
+  FiEdit3,
+  FiExternalLink,
   FiMail,
+  FiMapPin,
+  FiNavigation,
   FiPhone,
   FiPlus,
   FiSearch,
@@ -19,6 +23,7 @@ import type { Booking } from '@/lib/coach-booking'
 import type { StudentProgress, StudentProgressEntry } from '@/lib/coach-student-progress'
 import { GENERIC_USER_ERROR, reportInternalError } from '@/lib/user-facing-error'
 import AddStudentModal, { type CreatedStudentPayload } from './AddStudentModal'
+import EditStudentModal, { type UpdatedStudentPayload } from './EditStudentModal'
 import StudentProgressModal from './StudentProgressModal'
 
 interface StudentSummary {
@@ -26,6 +31,8 @@ interface StudentSummary {
   name: string
   email: string | null
   phone?: string
+  address?: string
+  location?: string
   totalClasses: number
   nextClass?: Booking
   upcomingClasses?: Booking[]
@@ -104,10 +111,35 @@ export default function CoachStudents() {
       )
     )
 
+  const updateStudentDetails = (updated: UpdatedStudentPayload) =>
+    setStudents((current) =>
+      current
+        ?.map((item) =>
+          item.athleteId === updated.athleteId
+            ? {
+                ...item,
+                name: updated.name,
+                email: updated.email,
+                phone: updated.phone,
+                address: updated.address,
+                location: updated.location,
+                progress: updated.progress,
+              }
+            : item
+        )
+        .sort((a, b) => a.name.localeCompare(b.name))
+    )
+
   const normalizedQuery = query.trim().toLowerCase()
   const visibleStudents = normalizedQuery
     ? students.filter((student) =>
-        [student.name, student.email || '', student.phone || '']
+        [
+          student.name,
+          student.email || '',
+          student.phone || '',
+          student.address || '',
+          student.location || '',
+        ]
           .join(' ')
           .toLowerCase()
           .includes(normalizedQuery)
@@ -153,6 +185,7 @@ export default function CoachStudents() {
               onProgressSaved={(entry, progress) =>
                 updateStudent(student.athleteId, entry, progress)
               }
+              onDetailsSaved={updateStudentDetails}
             />
           ))}
         </ul>
@@ -169,14 +202,17 @@ function StudentCard({
   student,
   focused = false,
   onProgressSaved,
+  onDetailsSaved,
 }: {
   student: StudentSummary
   focused?: boolean
   onProgressSaved: (entry: StudentProgressEntry, progress: StudentProgress) => void
+  onDetailsSaved: (student: UpdatedStudentPayload) => void
 }) {
   const [open, setOpen] = useState(focused)
   const [showAll, setShowAll] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
+  const [editModalOpen, setEditModalOpen] = useState(false)
   const ref = useRef<HTMLLIElement>(null)
 
   // When deep-linked from the agenda, open and scroll this card into view.
@@ -229,6 +265,27 @@ function StudentCard({
                 <FiPhone aria-hidden="true" /> {student.phone}
               </p>
             )}
+            {student.address && (
+              <p className="flex items-center gap-2 text-sm text-(--c-text-2)">
+                <FiMapPin aria-hidden="true" /> {student.address}
+              </p>
+            )}
+            {student.location &&
+              (isWebUrl(student.location) ? (
+                <a
+                  href={student.location}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-sm font-semibold text-(--c-aqua-strong) hover:underline"
+                >
+                  <FiNavigation aria-hidden="true" /> Ver ubicación
+                  <FiExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
+                </a>
+              ) : (
+                <p className="flex items-center gap-2 text-sm text-(--c-text-2)">
+                  <FiNavigation aria-hidden="true" /> {student.location}
+                </p>
+              ))}
             {student.upcomingClasses && student.upcomingClasses.length > 0 && (
               <div className="flex flex-col gap-1">
                 <p className="text-xs font-bold uppercase tracking-wide text-(--c-text-2)">
@@ -258,13 +315,22 @@ function StudentCard({
             />
           </div>
 
-          <button
-            type="button"
-            onClick={() => setModalOpen(true)}
-            className="inline-flex min-h-11 items-center justify-center gap-2 self-start rounded-full bg-(--c-ocean) px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90"
-          >
-            <FiPlus aria-hidden="true" /> Agregar progreso
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setEditModalOpen(true)}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-(--c-border) bg-white px-4 py-2 text-sm font-bold text-(--c-ocean) transition-colors hover:bg-(--c-surface)"
+            >
+              <FiEdit3 aria-hidden="true" /> Editar datos
+            </button>
+            <button
+              type="button"
+              onClick={() => setModalOpen(true)}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-full bg-(--c-ocean) px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-90"
+            >
+              <FiPlus aria-hidden="true" /> Agregar progreso
+            </button>
+          </div>
 
           <div className="flex flex-col gap-2">
             <h4 className="text-sm font-bold text-(--c-ocean)">Progresos registrados</h4>
@@ -308,8 +374,23 @@ function StudentCard({
           }}
         />
       )}
+
+      {editModalOpen && (
+        <EditStudentModal
+          student={student}
+          onClose={() => setEditModalOpen(false)}
+          onSaved={(updated) => {
+            onDetailsSaved(updated)
+            setEditModalOpen(false)
+          }}
+        />
+      )}
     </li>
   )
+}
+
+function isWebUrl(value: string) {
+  return /^https?:\/\//i.test(value.trim())
 }
 
 function EntryItem({ entry }: { entry: StudentProgressEntry }) {

--- a/components/coach/EditStudentModal.tsx
+++ b/components/coach/EditStudentModal.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useKeyboardSafeArea } from '@comps/hooks/useKeyboardSafeArea'
+import { useState } from 'react'
+import { putAuthed } from '@/lib/client/authed-api'
+import type { StudentProgress } from '@/lib/coach-student-progress'
+import { GENERIC_USER_ERROR, reportInternalError } from '@/lib/user-facing-error'
+
+export interface EditableStudentDetails {
+  athleteId: string
+  name: string
+  email: string | null
+  phone?: string
+  address?: string
+  location?: string
+  progress?: StudentProgress | null
+}
+
+export interface UpdatedStudentPayload {
+  athleteId: string
+  name: string
+  email: string | null
+  phone?: string
+  address?: string
+  location?: string
+  progress: StudentProgress
+}
+
+export default function EditStudentModal({
+  student,
+  onClose,
+  onSaved,
+}: {
+  student: EditableStudentDetails
+  onClose: () => void
+  onSaved: (student: UpdatedStudentPayload) => void
+}) {
+  const [name, setName] = useState(student.name)
+  const [email, setEmail] = useState(student.email || '')
+  const [phone, setPhone] = useState(student.phone || '')
+  const [address, setAddress] = useState(student.address || '')
+  const [location, setLocation] = useState(student.location || '')
+  const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle')
+  const keyboardSafeArea = useKeyboardSafeArea()
+  const canSubmit = name.trim().length > 1 && status !== 'saving'
+
+  async function save() {
+    if (!canSubmit) return
+
+    setStatus('saving')
+    try {
+      const response = await putAuthed('/api/coach/students', {
+        athleteId: student.athleteId,
+        name,
+        email,
+        phone,
+        address,
+        location,
+      })
+      const payload = (await response.json()) as { student: UpdatedStudentPayload }
+      onSaved(payload.student)
+    } catch (err) {
+      reportInternalError('COACH_STUDENT_UPDATE', err)
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Editar datos de ${student.name}`}
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-[rgba(10,37,64,0.55)] p-4 backdrop-blur-sm"
+      style={keyboardSafeArea ? { paddingBottom: `calc(${keyboardSafeArea}px + 1rem)` } : undefined}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose()
+      }}
+    >
+      <div className="flex max-h-[calc(100dvh-2rem)] w-full max-w-lg flex-col gap-4 overflow-y-auto rounded-[var(--r-md)] bg-white p-5 shadow-[var(--shadow-md)]">
+        <div className="mx-auto h-1 w-10 rounded-full bg-(--c-border) sm:hidden" />
+        <div>
+          <h3 className="text-xl font-bold text-(--c-ocean)">Editar alumno</h3>
+          <p className="mt-0.5 text-sm text-(--c-text-2)">
+            Actualiza los datos de contacto y ubicación de este alumno.
+          </p>
+        </div>
+
+        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
+          Nombre
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            maxLength={120}
+            className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
+          />
+        </label>
+
+        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
+          Correo
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            maxLength={160}
+            placeholder="Opcional"
+            className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
+          />
+        </label>
+
+        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
+          Teléfono
+          <input
+            type="tel"
+            value={phone}
+            onChange={(event) => setPhone(event.target.value)}
+            maxLength={40}
+            placeholder="Opcional"
+            className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
+          />
+        </label>
+
+        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
+          Dirección
+          <input
+            value={address}
+            onChange={(event) => setAddress(event.target.value)}
+            maxLength={240}
+            placeholder="Opcional"
+            className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
+          />
+        </label>
+
+        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
+          Ubicación
+          <input
+            value={location}
+            onChange={(event) => setLocation(event.target.value)}
+            maxLength={500}
+            placeholder="Link de Google Maps o referencia"
+            className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
+          />
+        </label>
+
+        {status === 'error' && (
+          <p className="text-sm text-(--c-error,#b91c1c)">{GENERIC_USER_ERROR}</p>
+        )}
+
+        <div className="mt-1 flex flex-col gap-2">
+          <button
+            type="button"
+            disabled={!canSubmit}
+            onClick={save}
+            className="min-h-12 rounded-full bg-(--c-ocean) font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+          >
+            {status === 'saving' ? 'Guardando...' : 'Guardar cambios'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="min-h-11 rounded-full font-semibold text-(--c-text-2) hover:text-(--c-ocean)"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/client/authed-api.ts
+++ b/lib/client/authed-api.ts
@@ -29,13 +29,19 @@ export function postAuthed(path: string, body?: unknown) {
   })
 }
 
+export function putAuthed(path: string, body?: unknown) {
+  return requestAuthed(path, {
+    method: 'PUT',
+    body: JSON.stringify(body || {}),
+  })
+}
+
 export function patchAuthed(path: string, body?: unknown) {
   return requestAuthed(path, {
     method: 'PATCH',
     body: JSON.stringify(body || {}),
   })
 }
-
 
 export function deleteAuthed(path: string) {
   return requestAuthed(path, { method: 'DELETE' })

--- a/lib/coach-student-progress.ts
+++ b/lib/coach-student-progress.ts
@@ -15,6 +15,8 @@ export interface StudentProgress {
   athleteName: string
   athleteEmail: string | null
   athletePhone?: string
+  athleteAddress?: string
+  athleteLocation?: string
   level: StudentLevel
   goal: string
   lastNote: string


### PR DESCRIPTION
## Summary
- add an Editar datos action to coach student cards
- add a modal to edit name, email, phone, address, and location
- persist edited details in coachStudentProgress and sync name/email/phone to existing bookings

## Tests
- corepack pnpm exec biome check components/coach/CoachStudents.tsx components/coach/EditStudentModal.tsx app/api/coach/students/route.ts lib/coach-student-progress.ts lib/client/authed-api.ts
- corepack pnpm exec tsc --noEmit --pretty false

## Note
- corepack pnpm run build currently fails while prerendering /privacidad with: "undefined" is not valid JSON