### PR TITLE
Fix clipboard fallback for WhatsApp schedule copy

### DIFF
--- a/components/coach/CoachAgenda.tsx
+++ b/components/coach/CoachAgenda.tsx
@@ -4,9 +4,11 @@ import Loading from '@comps/Loading'
 import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  FiCheck,
   FiChevronLeft,
   FiChevronRight,
   FiClock,
+  FiCopy,
   FiEdit2,
   FiLock,
   FiPlus,
@@ -18,6 +20,7 @@ import { useUser } from '@/context/UserContext'
 import type { CoachClassOffering } from '@/firebase/coaches/coach.model'
 import { CoachCRUD } from '@/firebase/coaches/main'
 import { deleteAuthed, getAuthed, postAuthed } from '@/lib/client/authed-api'
+import { copyTextToClipboard } from '@/lib/client/copy-to-clipboard'
 import type { CoachAgendaPayload, CoachAvailableSlot, CoachScheduleBlock } from '@/lib/coach-agenda'
 import { HOUR_STATUS_STYLE, type HourStatus } from '@/lib/coach-agenda-status'
 import type { Booking } from '@/lib/coach-booking'
@@ -35,6 +38,11 @@ import {
   offeringWithoutHours,
   startOfWeek,
 } from '@/lib/coach-offerings'
+import {
+  DAY_LABELS,
+  formatWhatsappScheduleText,
+  type WhatsappScheduleDay,
+} from '@/lib/coach-whatsapp-schedule'
 import { GENERIC_USER_ERROR, reportInternalError } from '@/lib/user-facing-error'
 import AgendaAddStudentModal, { type AddStudentPayload } from './AgendaAddStudentModal'
 import AgendaOpenHoursModal, {
@@ -86,6 +94,8 @@ export default function CoachAgenda({ coachId }: { coachId?: string }) {
   const [detailsModalOpen, setDetailsModalOpen] = useState(false)
   const [hoursEditorOpen, setHoursEditorOpen] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
+  const [whatsappCopied, setWhatsappCopied] = useState(false)
+  const [whatsappCopyFailed, setWhatsappCopyFailed] = useState(false)
 
   const monthOfSelected = selectedDate.slice(0, 7)
 
@@ -217,6 +227,38 @@ export default function CoachAgenda({ coachId }: { coachId?: string }) {
     }
     return { booked, total }
   }, [weekDates, dayStatuses])
+
+  const offeringGroupTypes = useMemo(() => {
+    return new Map((agenda?.offerings || []).map((item) => [item.id, item.groupType]))
+  }, [agenda?.offerings])
+
+  const whatsappDayRows = useMemo<WhatsappScheduleDay[]>(() => {
+    return weekDates
+      .map((date) => {
+        const key = dateKey(date)
+        const dayKey = whatsappDayKey(date)
+        const slots = (agenda?.availableSlots || [])
+          .filter((slot) => slot.date === key)
+          .sort((a, b) => a.startTime.localeCompare(b.startTime))
+
+        return {
+          dayKey,
+          dayLabel: DAY_LABELS[dayKey] || dayKey,
+          times: slots.map((slot) => ({
+            label: `${slot.startTime} - ${slot.endTime}`,
+            disabled: slot.status !== 'available' || slotHasPassed(slot),
+            groupType: offeringGroupTypes.get(slot.offeringId) || null,
+          })),
+        }
+      })
+      .filter((day) => day.times.length > 0)
+  }, [agenda?.availableSlots, offeringGroupTypes, weekDates])
+
+  const whatsappScheduleText = useMemo(() => {
+    return formatWhatsappScheduleText(whatsappDayRows, weekDates[0] || new Date())
+  }, [whatsappDayRows, weekDates])
+
+  const canCopyWhatsappSchedule = whatsappScheduleText.length > 0
 
   const dayBookings = activeBookings.filter((booking) => booking.date === selectedDate)
   const daySlots = (agenda?.availableSlots || []).filter((slot) => slot.date === selectedDate)
@@ -451,6 +493,20 @@ export default function CoachAgenda({ coachId }: { coachId?: string }) {
     eliminarSlot(action.slot)
   }
 
+  async function copyWhatsappSchedule() {
+    if (!whatsappScheduleText) return
+
+    setWhatsappCopyFailed(false)
+    try {
+      await copyTextToClipboard(whatsappScheduleText)
+      setWhatsappCopied(true)
+      setTimeout(() => setWhatsappCopied(false), 2000)
+    } catch {
+      setWhatsappCopyFailed(true)
+      setTimeout(() => setWhatsappCopyFailed(false), 3000)
+    }
+  }
+
   if (agenda === undefined) return <Loading />
 
   return (
@@ -476,6 +532,28 @@ export default function CoachAgenda({ coachId }: { coachId?: string }) {
         onNext={() => changeWeek(1)}
         labelClassName="text-sm font-semibold"
       />
+
+      <div className="flex justify-center">
+        <button
+          type="button"
+          onClick={() => void copyWhatsappSchedule()}
+          disabled={!canCopyWhatsappSchedule}
+          aria-label="Copiar horarios para WhatsApp"
+          className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-full border border-[var(--c-border)] bg-white px-3.5 py-2 text-sm font-bold text-[var(--c-ocean)] transition-colors hover:border-[var(--c-aqua)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--c-aqua-strong)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {whatsappCopied ? (
+            <>
+              <FiCheck aria-hidden="true" /> Copiado
+            </>
+          ) : whatsappCopyFailed ? (
+            'No se pudo copiar'
+          ) : (
+            <>
+              <FiCopy aria-hidden="true" /> Copiar para WhatsApp
+            </>
+          )}
+        </button>
+      </div>
 
       <p className="text-center text-sm text-[var(--c-text-2)]">
         {adminMode
@@ -1011,6 +1089,14 @@ function initials(name: string) {
 function weekdayChipLabel(date: Date) {
   const weekday = date.toLocaleDateString('es-MX', { weekday: 'short' }).replace('.', '')
   return `${weekday.charAt(0).toUpperCase()}${weekday.slice(1)} ${date.getDate()}`
+}
+
+function whatsappDayKey(date: Date) {
+  return ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'][date.getDay()] || ''
+}
+
+function slotHasPassed(slot: Pick<CoachAvailableSlot, 'date' | 'startTime'>) {
+  return new Date(`${slot.date}T${slot.startTime}:00`).getTime() <= Date.now()
 }
 
 // Next 7 days as selectable chips for the offering editor modal.

--- a/components/coach/CoachPublicProfile.tsx
+++ b/components/coach/CoachPublicProfile.tsx
@@ -10,6 +10,7 @@ import { FiCheck, FiCopy } from 'react-icons/fi'
 import { useUser } from '@/context/UserContext'
 import type { CoachPublic } from '@/firebase/coaches/coach.model'
 import { auth } from '@/firebase/index'
+import { copyTextToClipboard } from '@/lib/client/copy-to-clipboard'
 import {
   bookingSelectionKey,
   type CoachBookingSelection,
@@ -502,7 +503,7 @@ export default function CoachPublicProfile({
 
     setWhatsappCopyFailed(false)
     try {
-      await navigator.clipboard.writeText(whatsappScheduleText)
+      await copyTextToClipboard(whatsappScheduleText)
       setWhatsappCopied(true)
       setTimeout(() => setWhatsappCopied(false), 2000)
     } catch {

--- a/components/coach/CoachPublicProfile.tsx
+++ b/components/coach/CoachPublicProfile.tsx
@@ -29,28 +29,9 @@ import {
   scheduleIsOpen,
 } from '@/lib/coach-offerings'
 import { coachDisplayPhoto } from '@/lib/coach-photo'
+import { DAY_LABELS, formatWhatsappScheduleText } from '@/lib/coach-whatsapp-schedule'
 import CoachScheduleRows from './CoachScheduleRows'
 import VerifiedBadge from './VerifiedBadge'
-
-const DAY_LABELS: Record<string, string> = {
-  Lun: 'Lunes',
-  Mar: 'Martes',
-  Mié: 'Miércoles',
-  Jue: 'Jueves',
-  Vie: 'Viernes',
-  Sáb: 'Sábado',
-  Dom: 'Domingo',
-}
-
-const DAY_WHATSAPP_EMOJIS: Record<string, string> = {
-  Lun: '🌞',
-  Mar: '🌼',
-  Mié: '🌻',
-  Jue: '🌺',
-  Vie: '🪷',
-  Sáb: '🌿',
-  Dom: '☀️',
-}
 
 interface CurrentUser {
   nickname?: string
@@ -142,10 +123,6 @@ function todayStart() {
   const today = new Date()
   today.setHours(0, 0, 0, 0)
   return today
-}
-
-function whatsappWeekLabel(date: Date) {
-  return date.toLocaleDateString('es-MX', { day: 'numeric', month: 'long' })
 }
 
 function whatsappUrl(coach: CoachPublic, message: string) {
@@ -331,24 +308,7 @@ export default function CoachPublicProfile({
     [bookingSelections, coach, bookedSlotCounts, bookedHours, isBlocked]
   )
   const whatsappScheduleText = useMemo(() => {
-    if (whatsappDayRows.length === 0) return ''
-
-    const daysText = whatsappDayRows
-      .map(
-        (day) =>
-          `${DAY_WHATSAPP_EMOJIS[day.dayKey] || '▫️'} ${day.dayLabel}\n${day.times
-            .map((time) => {
-              const marker = time.disabled ? '❌' : '▫️'
-              const groupLabel = time.groupType === 'grupal' ? ' (Clases grupales)' : ''
-              return `${marker} ${time.label}${groupLabel}`
-            })
-            .join('\n')}`
-      )
-      .join('\n\n')
-
-    return `📅 HORARIOS DISPONIBLES\nSemana ${whatsappWeekLabel(
-      periodStart
-    )}\n\n${daysText}\n\n✅ Los espacios se asignan conforme se van reservando.\n💬 Indícame qué día y horario te interesa para agendar tu lugar.\n⏱️ Cancelación mínima de 24 horas para las clases agendadas. En caso contrario se acredita la clase.`
+    return formatWhatsappScheduleText(whatsappDayRows, periodStart)
   }, [whatsappDayRows, periodStart])
   const canCopyWhatsappSchedule = whatsappScheduleText.length > 0
 

--- a/components/coach/CopyLinkButton.tsx
+++ b/components/coach/CopyLinkButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { FiCheck, FiShare2 } from 'react-icons/fi'
+import { copyTextToClipboard } from '@/lib/client/copy-to-clipboard'
 
 /** Copies the current page URL (the public coach link) to the clipboard. */
 export default function CopyLinkButton({
@@ -17,7 +18,7 @@ export default function CopyLinkButton({
   const copy = async () => {
     setFailed(false)
     try {
-      await navigator.clipboard.writeText(window.location.href)
+      await copyTextToClipboard(window.location.href)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {

--- a/components/coach/ShareScheduleButton.tsx
+++ b/components/coach/ShareScheduleButton.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { FiCheck, FiShare2 } from 'react-icons/fi'
 import { useUser } from '@/context/UserContext'
 import { getAuthed } from '@/lib/client/authed-api'
+import { copyTextToClipboard } from '@/lib/client/copy-to-clipboard'
 
 export default function ShareScheduleButton() {
   const { user } = useUser()
@@ -33,7 +34,7 @@ export default function ShareScheduleButton() {
     const link = `${window.location.origin}/${coachSlug || uid}`
     setFailed(false)
     try {
-      await navigator.clipboard.writeText(link)
+      await copyTextToClipboard(link)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {

--- a/lib/client/copy-to-clipboard.ts
+++ b/lib/client/copy-to-clipboard.ts
@@ -1,0 +1,32 @@
+'use client'
+
+export async function copyTextToClipboard(text: string) {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch {
+      // Fall through to the textarea fallback for embedded browsers/iframes.
+    }
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.top = '0'
+  textarea.style.left = '0'
+  textarea.style.opacity = '0'
+
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  textarea.setSelectionRange(0, text.length)
+
+  try {
+    const copied = document.execCommand('copy')
+    if (!copied) throw new Error('copy_failed')
+  } finally {
+    document.body.removeChild(textarea)
+  }
+}

--- a/lib/coach-whatsapp-schedule.ts
+++ b/lib/coach-whatsapp-schedule.ts
@@ -1,0 +1,54 @@
+export const DAY_LABELS: Record<string, string> = {
+  Lun: 'Lunes',
+  Mar: 'Martes',
+  Mié: 'Miércoles',
+  Jue: 'Jueves',
+  Vie: 'Viernes',
+  Sáb: 'Sábado',
+  Dom: 'Domingo',
+}
+
+export const DAY_WHATSAPP_EMOJIS: Record<string, string> = {
+  Lun: '🌞',
+  Mar: '🌼',
+  Mié: '🌻',
+  Jue: '🌺',
+  Vie: '🪷',
+  Sáb: '🌿',
+  Dom: '☀️',
+}
+
+export type WhatsappScheduleDay = {
+  dayKey: string
+  dayLabel: string
+  times: {
+    label: string
+    disabled: boolean
+    groupType?: string | null
+  }[]
+}
+
+export function whatsappWeekLabel(date: Date) {
+  return date.toLocaleDateString('es-MX', { day: 'numeric', month: 'long' })
+}
+
+export function formatWhatsappScheduleText(days: WhatsappScheduleDay[], periodStart: Date) {
+  if (days.length === 0) return ''
+
+  const daysText = days
+    .map(
+      (day) =>
+        `${DAY_WHATSAPP_EMOJIS[day.dayKey] || '▫️'} ${day.dayLabel}\n${day.times
+          .map((time) => {
+            const marker = time.disabled ? '❌' : '▫️'
+            const groupLabel = time.groupType === 'grupal' ? ' (Clases grupales)' : ''
+            return `${marker} ${time.label}${groupLabel}`
+          })
+          .join('\n')}`
+    )
+    .join('\n\n')
+
+  return `📅 HORARIOS DISPONIBLES\nSemana ${whatsappWeekLabel(
+    periodStart
+  )}\n\n${daysText}\n\n✅ Los espacios se asignan conforme se van reservando.\n💬 Indícame qué día y horario te interesa para agendar tu lugar.\n⏱️ Cancelación mínima de 24 horas para las clases agendadas. En caso contrario se acredita la clase.`
+}


### PR DESCRIPTION
## Summary
- Add a shared clipboard helper with a textarea fallback when navigator.clipboard is blocked
- Use it for the WhatsApp schedule copy button and schedule share buttons

## Checks
- corepack pnpm exec biome check components/coach/CoachPublicProfile.tsx components/coach/CopyLinkButton.tsx components/coach/ShareScheduleButton.tsx lib/client/copy-to-clipboard.ts
- corepack pnpm exec tsc --noEmit --pretty false