### PR TITLE
Order coach directory by verified schedules

### DIFF
--- a/app/(marketing)/[id]/page.tsx
+++ b/app/(marketing)/[id]/page.tsx
@@ -85,14 +85,12 @@ export default async function PublicProfilePage({ params }: PublicProfilePagePro
   return (
     <section className="mx-auto max-w-[1040px] px-5 py-6 sm:px-8 lg:py-8">
       <JsonLd data={jsonLd} />
-      <div className="rounded-[32px] border border-[var(--c-border)] bg-[var(--c-bg)] p-5 shadow-[var(--shadow-sm)] sm:p-7">
-        <CoachPublicProfile
-          coach={detail.coach}
-          name={detail.name}
-          bookedSlots={detail.bookedSlots}
-          blockedSlots={detail.blockedSlots}
-        />
-      </div>
+      <CoachPublicProfile
+        coach={detail.coach}
+        name={detail.name}
+        bookedSlots={detail.bookedSlots}
+        blockedSlots={detail.blockedSlots}
+      />
     </section>
   )
 }

--- a/app/(marketing)/coach/[id]/page.tsx
+++ b/app/(marketing)/coach/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function CoachPublicPage({ params }: CoachPublicPageProps) 
         Volver a coaches
       </Link>
 
-      <div className="mt-6 rounded-[32px] border border-[var(--c-border)] bg-[var(--c-bg)] p-5 shadow-[var(--shadow-sm)] sm:p-7">
+      <div className="mt-8">
         <CoachPublicProfile
           coach={detail.coach}
           name={detail.name}

--- a/app/api/public/coaches/route.ts
+++ b/app/api/public/coaches/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { CoachPublic } from '@/firebase/coaches/coach.model'
+import { hasPublishedOfferingSchedules, resolveOfferings } from '@/lib/coach-offerings'
 import { publicNameFromUser } from '@/lib/public-name'
 import { adminDb } from '@/lib/server/firebase-admin'
 
@@ -7,6 +8,20 @@ interface PublicCoachDirectoryItem extends CoachPublic {
   id: string
   name: string
   avatarUrl?: string
+}
+
+function coachDirectoryPriority(coach: PublicCoachDirectoryItem) {
+  const verified = coach.verification?.status === 'verified'
+  const hasSchedules = hasPublishedOfferingSchedules(resolveOfferings(coach))
+
+  if (verified && hasSchedules) return 0
+  if (verified) return 1
+  if (hasSchedules) return 2
+  return 3
+}
+
+function sortCoachDirectory(a: PublicCoachDirectoryItem, b: PublicCoachDirectoryItem) {
+  return coachDirectoryPriority(a) - coachDirectoryPriority(b) || a.name.localeCompare(b.name, 'es')
 }
 
 export async function GET() {
@@ -35,7 +50,7 @@ export async function GET() {
       })
     )
 
-    return NextResponse.json({ coaches })
+    return NextResponse.json({ coaches: coaches.sort(sortCoachDirectory) })
   } catch (error) {
     console.error('[PUBLIC_COACH_DIRECTORY]', error)
     return NextResponse.json({ coaches: [] }, { status: 500 })

--- a/components/coach/CoachScheduleRows.tsx
+++ b/components/coach/CoachScheduleRows.tsx
@@ -32,7 +32,7 @@ export default function CoachScheduleRows({
   }
 
   return (
-    <div className="space-y-3 rounded-2xl border border-[var(--c-border)] bg-[var(--c-surface)] px-4 py-3">
+    <div className="my-3 space-y-4 rounded-[24px] border border-[var(--c-border)] bg-[var(--c-surface)] px-5 py-5 sm:px-6">
       {days.map((day) => (
         <div key={day.key} className="grid gap-1 sm:grid-cols-[7rem_1fr]">
           <div>

--- a/components/marketing/CachedCoachProfileLoading.tsx
+++ b/components/marketing/CachedCoachProfileLoading.tsx
@@ -29,7 +29,7 @@ export default function CachedCoachProfileLoading() {
         Volver a coaches
       </Link>
 
-      <div className="mt-6 rounded-[32px] border border-[var(--c-border)] bg-[var(--c-bg)] p-5 shadow-[var(--shadow-sm)] sm:p-7">
+      <div className="mt-8">
         <CoachPublicProfile coach={cached.coach} name={cached.name} />
       </div>
     </section>

--- a/lib/coach-offerings.ts
+++ b/lib/coach-offerings.ts
@@ -172,6 +172,12 @@ export function offeringsAvailabilitySummary(offerings: CoachClassOffering[]): s
   return `${weeklySlotCount} ${weeklySlotCount === 1 ? 'horario' : 'horarios'} por semana`
 }
 
+export function hasPublishedOfferingSchedules(offerings: CoachClassOffering[]): boolean {
+  return offerings
+    .flatMap(resolveOfferingSchedules)
+    .some((schedule) => scheduleIsOpen(schedule) || schedule.days.length > 0)
+}
+
 export function resolveOfferingSchedules(offering: CoachClassOffering): CoachOfferingSchedule[] {
   if (offering.schedules?.length) return offering.schedules
   if (offering.days?.length && offering.startTime && offering.endTime) {


### PR DESCRIPTION
## Summary
- prioritize verified coaches with published schedules in the public coach directory
- reuse the offering schedule resolver so legacy and unified schedule data count consistently

## Validation
- ./node_modules/.bin/biome check app/api/public/coaches/route.ts lib/coach-offerings.ts
- ./node_modules/.bin/tsc --noEmit