### PR TITLE
Fix public coach and athlete slugs

### DIFF
--- a/app/(app)/athlete/coach/[id]/page.tsx
+++ b/app/(app)/athlete/coach/[id]/page.tsx
@@ -1,46 +1,22 @@
-'use client'
 import CoachPublicProfile from '@comps/coach/CoachPublicProfile'
-import Loading from '@comps/Loading'
-import { use, useEffect, useState } from 'react'
-import type { CoachPublic } from '@/firebase/coaches/coach.model'
-import type { PublicBlockedSlot, PublicBookedSlot } from '@/lib/coach-booking'
+import { notFound, redirect } from 'next/navigation'
+import { getPublicCoachDetail } from '@/lib/server/public-coach'
+import { resolveSlug } from '@/lib/server/slugs'
 
-interface CoachDetail {
-  coach: CoachPublic
-  name: string
-  avatarUrl: string | null
-  bookedSlots?: PublicBookedSlot[]
-  blockedSlots?: PublicBlockedSlot[]
+interface AthleteCoachViewProps {
+  params: Promise<{ id: string }>
 }
 
-export default function AthleteCoachView({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
-  const [detail, setDetail] = useState<CoachDetail | null | undefined>(undefined)
+export default async function AthleteCoachView({ params }: AthleteCoachViewProps) {
+  const { id } = await params
+  const target = await resolveSlug(id, 'coach')
+  if (!target) notFound()
 
-  useEffect(() => {
-    let active = true
-    fetch(`/api/public/coaches/${id}`)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((payload) => {
-        if (!active) return
-        setDetail(payload?.coach ? (payload as CoachDetail) : null)
-      })
-      .catch(() => active && setDetail(null))
-    return () => {
-      active = false
-    }
-  }, [id])
+  const detail = await getPublicCoachDetail(target.uid)
+  if (!detail) notFound()
 
-  if (detail === undefined) return <Loading />
-  if (detail === null) {
-    return (
-      <div className="flex flex-col gap-4">
-        <h1 className="text-3xl font-extrabold">Coach</h1>
-        <div className="rounded-[var(--r-md)] border border-[var(--c-border)] bg-[var(--c-surface)] p-10 text-center text-[var(--c-text-2)]">
-          Perfil no disponible
-        </div>
-      </div>
-    )
+  if (detail.coachSlug && detail.coachSlug !== id) {
+    redirect(`/${detail.coachSlug}`)
   }
 
   return (
@@ -48,8 +24,8 @@ export default function AthleteCoachView({ params }: { params: Promise<{ id: str
       coach={detail.coach}
       name={detail.name}
       avatarUrl={detail.avatarUrl}
-      bookedSlots={detail.bookedSlots || []}
-      blockedSlots={detail.blockedSlots || []}
+      bookedSlots={detail.bookedSlots}
+      blockedSlots={detail.blockedSlots}
     />
   )
 }

--- a/app/(marketing)/[id]/opengraph-image.tsx
+++ b/app/(marketing)/[id]/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from 'next/og'
 import { coachDisplayPhoto } from '@/lib/coach-photo'
-import { getPublicAthleteDetail } from '@/lib/server/public-athlete'
 import { getPublicCoachDetail } from '@/lib/server/public-coach'
 import { resolveSlug } from '@/lib/server/slugs'
 
@@ -35,7 +34,7 @@ function initials(name: string) {
 
 export default async function Image({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const target = await resolveSlug(id)
+  const target = await resolveSlug(id, 'coach')
 
   let name = 'nadamas.app'
   let subtitle = 'Coach de natación'
@@ -47,13 +46,6 @@ export default async function Image({ params }: { params: Promise<{ id: string }
       name = detail.name
       subtitle = 'Coach de natación'
       photo = coachDisplayPhoto(detail.coach)
-    }
-  } else if (target?.kind === 'athlete') {
-    const detail = await getPublicAthleteDetail(target.uid)
-    if (detail) {
-      name = detail.name
-      subtitle = 'Nadador'
-      photo = detail.photoURL
     }
   }
 

--- a/app/(marketing)/[id]/page.tsx
+++ b/app/(marketing)/[id]/page.tsx
@@ -1,10 +1,8 @@
-import AthletePublicProfile from '@comps/athlete/AthletePublicProfile'
 import CoachPublicProfile from '@comps/coach/CoachPublicProfile'
 import JsonLd from '@comps/JsonLd'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { coachDisplayPhoto } from '@/lib/coach-photo'
-import { getPublicAthleteDetail } from '@/lib/server/public-athlete'
 import { getPublicCoachDetail } from '@/lib/server/public-coach'
 import { resolveSlug } from '@/lib/server/slugs'
 
@@ -16,24 +14,14 @@ const METADATA_BASE = new URL('https://nadamas.app')
 
 export async function generateMetadata({ params }: PublicProfilePageProps): Promise<Metadata> {
   const { id } = await params
-  const target = await resolveSlug(id)
+  const target = await resolveSlug(id, 'coach')
   if (!target) return { title: 'Perfil no disponible' }
 
-  let title: string
-  let description: string
-
-  if (target.kind === 'coach') {
-    const detail = await getPublicCoachDetail(target.uid)
-    if (!detail) return { title: 'Perfil no disponible' }
-    title = `${detail.name} · Coach de natación`
-    description =
-      detail.coach.bio || 'Perfil de coach de natación: estilo, clases y horarios disponibles.'
-  } else {
-    const detail = await getPublicAthleteDetail(target.uid)
-    if (!detail) return { title: 'Perfil no disponible' }
-    title = detail.name
-    description = detail.bio || 'Perfil de nadador en nadamas.'
-  }
+  const detail = await getPublicCoachDetail(target.uid)
+  if (!detail) return { title: 'Perfil no disponible' }
+  const title = `${detail.name} · Coach de natación`
+  const description =
+    detail.coach.bio || 'Perfil de coach de natación: estilo, clases y horarios disponibles.'
 
   // og:image / twitter:image come from the colocated opengraph-image.tsx
   // (1200×630 card with the profile photo) — do not set images here.
@@ -56,20 +44,8 @@ export async function generateMetadata({ params }: PublicProfilePageProps): Prom
 
 export default async function PublicProfilePage({ params }: PublicProfilePageProps) {
   const { id } = await params
-  const target = await resolveSlug(id)
+  const target = await resolveSlug(id, 'coach')
   if (!target) notFound()
-
-  if (target.kind === 'athlete') {
-    const athlete = await getPublicAthleteDetail(target.uid)
-    if (!athlete) notFound()
-    return (
-      <section className="mx-auto max-w-[640px] px-5 py-6 sm:px-8 lg:py-8">
-        <div className="rounded-[32px] border border-[var(--c-border)] bg-[var(--c-bg)] p-6 shadow-[var(--shadow-sm)] sm:p-8">
-          <AthletePublicProfile athlete={athlete} />
-        </div>
-      </section>
-    )
-  }
 
   const detail = await getPublicCoachDetail(target.uid)
   if (!detail) notFound()

--- a/app/(marketing)/atleta/[id]/page.tsx
+++ b/app/(marketing)/atleta/[id]/page.tsx
@@ -1,0 +1,56 @@
+import AthletePublicProfile from '@comps/athlete/AthletePublicProfile'
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { getPublicAthleteDetail } from '@/lib/server/public-athlete'
+import { resolveSlug } from '@/lib/server/slugs'
+
+interface PublicAthletePageProps {
+  params: Promise<{ id: string }>
+}
+
+const METADATA_BASE = new URL('https://nadamas.app')
+
+export async function generateMetadata({ params }: PublicAthletePageProps): Promise<Metadata> {
+  const { id } = await params
+  const target = await resolveSlug(id, 'athlete')
+  if (!target) return { title: 'Perfil no disponible' }
+
+  const detail = await getPublicAthleteDetail(target.uid)
+  if (!detail) return { title: 'Perfil no disponible' }
+
+  const title = detail.name
+  const description = detail.bio || 'Perfil de nadador en nadamas.'
+
+  return {
+    metadataBase: METADATA_BASE,
+    title,
+    description,
+    alternates: { canonical: `/atleta/${id}` },
+    openGraph: {
+      title,
+      description,
+      type: 'profile',
+      siteName: 'nadamas.app',
+      locale: 'es_MX',
+      url: `/atleta/${id}`,
+    },
+    twitter: { card: 'summary_large_image', title, description },
+  }
+}
+
+export default async function PublicAthletePage({ params }: PublicAthletePageProps) {
+  const { id } = await params
+  const target = await resolveSlug(id, 'athlete')
+  if (!target) notFound()
+
+  const athlete = await getPublicAthleteDetail(target.uid)
+  if (!athlete) notFound()
+
+  return (
+    <section className="mx-auto max-w-[640px] px-5 py-6 sm:px-8 lg:py-8">
+      <div className="rounded-[32px] border border-[var(--c-border)] bg-[var(--c-bg)] p-6 shadow-[var(--shadow-sm)] sm:p-8">
+        <AthletePublicProfile athlete={athlete} />
+      </div>
+    </section>
+  )
+}

--- a/app/api/public/coaches/route.ts
+++ b/app/api/public/coaches/route.ts
@@ -8,6 +8,7 @@ interface PublicCoachDirectoryItem extends CoachPublic {
   id: string
   name: string
   avatarUrl?: string
+  slug?: string
 }
 
 function coachDirectoryPriority(coach: PublicCoachDirectoryItem) {
@@ -40,6 +41,7 @@ export async function GET() {
           ...coach,
           id: doc.id,
           name: publicNameFromUser(user),
+          slug: typeof user?.slugs?.coach === 'string' ? user.slugs.coach : undefined,
           avatarUrl:
             typeof user?.photoURL === 'string'
               ? user.photoURL

--- a/app/api/slug/route.ts
+++ b/app/api/slug/route.ts
@@ -30,7 +30,9 @@ export async function GET(request: Request) {
   const slug = normalizeSlug(url.searchParams.get('slug') || '')
   if (!slug) return NextResponse.json({ valid: false, available: false })
   if (!isValidSlug(slug)) return NextResponse.json({ valid: false, available: false })
-  const available = await isSlugAvailable(slug, caller.uid)
+  const kind = parseKind(url.searchParams.get('kind'))
+  if (!kind) return NextResponse.json({ valid: false, available: false })
+  const available = await isSlugAvailable(slug, caller.uid, kind)
   return NextResponse.json({ valid: true, available })
 }
 
@@ -46,7 +48,7 @@ export async function POST(request: Request) {
   let requested = normalizeSlug(body.slug || '')
   if (!requested) {
     const snap = await adminDb.collection('users').doc(caller.uid).get()
-    requested = await ensureUniqueSlug(publicNameFromUser(snap.data()), caller.uid)
+    requested = await ensureUniqueSlug(publicNameFromUser(snap.data()), caller.uid, kind)
   }
 
   const result = await setSlug({ uid: caller.uid, kind, requested })

--- a/components/app-chrome/RoleSwitcher.tsx
+++ b/components/app-chrome/RoleSwitcher.tsx
@@ -149,7 +149,8 @@ export default function RoleSwitcher({
 
   const shareSlug = async (kind: 'coach' | 'athlete', slug: string) => {
     try {
-      await navigator.clipboard.writeText(`${window.location.origin}/${slug}`)
+      const path = kind === 'athlete' ? `/atleta/${slug}` : `/${slug}`
+      await navigator.clipboard.writeText(`${window.location.origin}${path}`)
       setCopiedKind(kind)
       setTimeout(() => setCopiedKind((current) => (current === kind ? null : current)), 2000)
     } catch {}
@@ -164,7 +165,7 @@ export default function RoleSwitcher({
         type="button"
         onClick={() => shareSlug(kind, slug)}
         aria-label={`Copiar enlace de ${ROLE_LABEL[kind]}`}
-        title={`nadamas.app/${slug}`}
+        title={kind === 'athlete' ? `nadamas.app/atleta/${slug}` : `nadamas.app/${slug}`}
         className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[var(--c-text-2)] transition-colors hover:bg-[var(--c-surface)] hover:text-[var(--c-ocean)]"
       >
         {copied ? (

--- a/components/coach/CoachDirectoryList.tsx
+++ b/components/coach/CoachDirectoryList.tsx
@@ -21,6 +21,7 @@ interface DirectoryCoach extends CoachPublic {
   id: string
   name: string
   avatarUrl?: string
+  slug?: string
 }
 
 const SKILL_LABELS: Record<string, Record<string, string>> = Object.fromEntries(
@@ -113,6 +114,7 @@ export default function CoachDirectoryList({
           {visible.map((coach) => {
             const tag = skillTag(coach)
             const availability = offeringsAvailabilitySummary(resolveOfferings(coach))
+            const coachHref = coach.slug ? `/${coach.slug}` : `${coachHrefBase}/${coach.id}`
             return (
               <li
                 key={coach.id}
@@ -138,7 +140,7 @@ export default function CoachDirectoryList({
                   )}
                 </div>
                 <Link
-                  href={`${coachHrefBase}/${coach.id}`}
+                  href={coachHref}
                   onClick={() => cacheCoachProfile(coach)}
                   className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[var(--c-border)] bg-white px-4 py-2.5 text-sm font-semibold text-[var(--c-ocean)] transition-colors hover:bg-[var(--c-surface)]"
                 >

--- a/components/profile/PublicLinkEditor.tsx
+++ b/components/profile/PublicLinkEditor.tsx
@@ -11,6 +11,11 @@ const KIND_LABEL: Record<SlugKind, string> = {
   athlete: 'Tu enlace de atleta',
 }
 
+const KIND_PREFIX: Record<SlugKind, string> = {
+  coach: 'nadamas.app/',
+  athlete: 'nadamas.app/atleta/',
+}
+
 function SlugRow({
   kind,
   initial,
@@ -59,7 +64,7 @@ function SlugRow({
       <span className="text-sm font-semibold text-[var(--c-ocean)]">{KIND_LABEL[kind]}</span>
       <div className="flex items-stretch gap-2">
         <span className="flex min-w-0 flex-1 items-center rounded-[var(--r-sm)] border border-[var(--c-border)] bg-white pl-3 text-sm">
-          <span className="shrink-0 text-[var(--c-text-2)]">nadamas.app/</span>
+          <span className="shrink-0 text-[var(--c-text-2)]">{KIND_PREFIX[kind]}</span>
           <input
             value={value}
             onChange={(event) => setValue(event.target.value)}
@@ -116,7 +121,7 @@ export default function PublicLinkEditor() {
       <div>
         <h2 className="text-lg font-bold">Tu enlace público</h2>
         <p className="mt-1 text-sm text-[var(--c-text-2)]">
-          Comparte un enlace corto a tu perfil. Cada enlace debe ser único.
+          Comparte un enlace corto a tu perfil. Cada enlace debe ser único por tipo de perfil.
         </p>
       </div>
       <SlugRow kind="athlete" initial={slugs.athlete || ''} suggestion={suggestion} />

--- a/lib/server/public-coach.ts
+++ b/lib/server/public-coach.ts
@@ -20,6 +20,13 @@ export async function getPublicCoachDetail(id: string) {
   return {
     coach,
     name: publicNameFromUser(user),
+    avatarUrl:
+      typeof user?.photoURL === 'string'
+        ? user.photoURL
+        : typeof user?.photoUrl === 'string'
+          ? user.photoUrl
+          : null,
+    coachSlug: typeof user?.slugs?.coach === 'string' ? user.slugs.coach : null,
     bookedSlots,
     blockedSlots,
   }

--- a/lib/server/slugs.ts
+++ b/lib/server/slugs.ts
@@ -11,28 +11,61 @@ interface SlugDoc {
   updatedAt: number
 }
 
-/** Resolve a public path segment to its owner. Tries the slug registry first,
- * then falls back to a raw coach uid (back-compat for old /<uid> links). */
-export async function resolveSlug(param: string): Promise<{ uid: string; kind: SlugKind } | null> {
+function slugDocId(kind: SlugKind, slug: string) {
+  return `${kind}:${slug}`
+}
+
+async function readSlugDoc(slug: string, kind: SlugKind) {
+  const scopedSnap = await adminDb.collection('slugs').doc(slugDocId(kind, slug)).get()
+  if (scopedSnap.exists) return scopedSnap
+
+  const legacySnap = await adminDb.collection('slugs').doc(slug).get()
+  if (legacySnap.exists && (legacySnap.data() as SlugDoc).kind === kind) return legacySnap
+
+  return null
+}
+
+async function findUserUidBySlug(slug: string, kind: SlugKind) {
+  const snap = await adminDb.collection('users').where(`slugs.${kind}`, '==', slug).limit(1).get()
+  return snap.docs[0]?.id ?? null
+}
+
+/** Resolve a public path segment to its owner. Slugs are scoped by profile kind
+ * so coach /zarza and athlete /atleta/zarza can coexist. */
+export async function resolveSlug(
+  param: string,
+  kind: SlugKind
+): Promise<{ uid: string; kind: SlugKind } | null> {
   const slug = normalizeSlug(param)
-  const slugSnap = await adminDb.collection('slugs').doc(slug).get()
-  if (slugSnap.exists) {
+  const slugSnap = await readSlugDoc(slug, kind)
+  if (slugSnap?.exists) {
     const data = slugSnap.data() as SlugDoc
     return { uid: data.uid, kind: data.kind }
   }
-  const coachSnap = await adminDb.collection('coaches').doc(param).get()
-  if (coachSnap.exists) return { uid: param, kind: 'coach' }
+
+  const uidFromUserSlug = await findUserUidBySlug(slug, kind)
+  if (uidFromUserSlug) return { uid: uidFromUserSlug, kind }
+
+  if (kind === 'coach') {
+    const coachSnap = await adminDb.collection('coaches').doc(param).get()
+    if (coachSnap.exists) return { uid: param, kind: 'coach' }
+  }
+
   return null
 }
 
 /** Find a free slug starting from `base`, appending -2, -3, … on collisions. */
-export async function ensureUniqueSlug(base: string, ownerUid: string): Promise<string> {
+export async function ensureUniqueSlug(
+  base: string,
+  ownerUid: string,
+  kind: SlugKind
+): Promise<string> {
   const root = slugify(base) || 'usuario'
   for (let attempt = 0; attempt < 50; attempt++) {
     const candidate = attempt === 0 ? root : `${root}-${attempt + 1}`
     if (!isValidSlug(candidate)) continue
-    const snap = await adminDb.collection('slugs').doc(candidate).get()
-    if (!snap.exists || (snap.data() as SlugDoc).uid === ownerUid) return candidate
+    const snap = await readSlugDoc(candidate, kind)
+    if (!snap?.exists || (snap.data() as SlugDoc).uid === ownerUid) return candidate
   }
   // Extremely unlikely fallback: suffix with part of the uid.
   return `${root}-${ownerUid.slice(0, 6).toLowerCase()}`
@@ -50,12 +83,20 @@ export async function setSlug(args: {
   const slug = normalizeSlug(args.requested)
   if (!isValidSlug(slug)) return { ok: false, reason: 'invalid' }
 
-  const slugRef = adminDb.collection('slugs').doc(slug)
+  const ownerFromUserSlug = await findUserUidBySlug(slug, args.kind)
+  if (ownerFromUserSlug && ownerFromUserSlug !== args.uid) return { ok: false, reason: 'taken' }
+
+  const slugRef = adminDb.collection('slugs').doc(slugDocId(args.kind, slug))
+  const legacySlugRef = adminDb.collection('slugs').doc(slug)
   const userRef = adminDb.collection('users').doc(args.uid)
 
   return adminDb.runTransaction(async (tx) => {
-    const existing = await tx.get(slugRef)
-    if (existing.exists && (existing.data() as SlugDoc).uid !== args.uid) {
+    const [existing, legacyExisting] = await Promise.all([tx.get(slugRef), tx.get(legacySlugRef)])
+    const legacyData = legacyExisting.exists ? (legacyExisting.data() as SlugDoc) : null
+    if (
+      (existing.exists && (existing.data() as SlugDoc).uid !== args.uid) ||
+      (legacyData?.kind === args.kind && legacyData.uid !== args.uid)
+    ) {
       return { ok: false as const, reason: 'taken' as const }
     }
 
@@ -66,6 +107,7 @@ export async function setSlug(args: {
     const now = Date.now()
 
     if (previous && previous !== slug) {
+      tx.delete(adminDb.collection('slugs').doc(slugDocId(args.kind, previous)))
       tx.delete(adminDb.collection('slugs').doc(previous))
     }
     tx.set(slugRef, {
@@ -80,10 +122,16 @@ export async function setSlug(args: {
   })
 }
 
-/** Whether `requested` can be claimed by `uid` (free or already theirs). */
-export async function isSlugAvailable(requested: string, uid: string): Promise<boolean> {
+/** Whether `requested` can be claimed by `uid` for this profile kind. */
+export async function isSlugAvailable(
+  requested: string,
+  uid: string,
+  kind: SlugKind
+): Promise<boolean> {
   const slug = normalizeSlug(requested)
   if (!isValidSlug(slug)) return false
-  const snap = await adminDb.collection('slugs').doc(slug).get()
-  return !snap.exists || (snap.data() as SlugDoc).uid === uid
+  const snap = await readSlugDoc(slug, kind)
+  if (snap?.exists) return (snap.data() as SlugDoc).uid === uid
+  const uidFromUserSlug = await findUserUidBySlug(slug, kind)
+  return !uidFromUserSlug || uidFromUserSlug === uid
 }

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -5,6 +5,7 @@ export type SlugKind = 'coach' | 'athlete'
 export const RESERVED_SLUGS = new Set([
   'api',
   'admin',
+  'atleta',
   'athlete',
   'athletes',
   'auth-gate',


### PR DESCRIPTION
## Summary
- keep coach public profiles at `/<slug>` and move athlete public profiles to `/atleta/<slug>`
- make slug validation profile-type aware so coach and athlete slugs do not conflict
- redirect legacy `/athlete/coach/[id]` links to the coach slug when available
- include coach slugs in public coach data so “Ver horarios” can link to the public URL

## Verification
- `corepack pnpm typecheck`
- `corepack pnpm biome check` on touched files
- `git diff --check`
