### PR TITLE
Fix coach share card metadata

### DIFF
--- a/app/(marketing)/[id]/opengraph-image.tsx
+++ b/app/(marketing)/[id]/opengraph-image.tsx
@@ -9,6 +9,7 @@ export const alt = 'Perfil en nadamas.app'
 
 const OCEAN = '#0A2540'
 const AQUA = '#0EA5C4'
+const MAX_SUMMARY_LENGTH = 132
 
 // Fetch the profile photo and inline it as a data URI so the OG renderer never
 // depends on the remote host being reachable at render time.
@@ -32,12 +33,21 @@ function initials(name: string) {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
 }
 
+function coachSummary(bio?: string) {
+  const fallback = 'Reserva tus clases de natación y revisa horarios disponibles.'
+  const summary = bio?.trim().replace(/\s+/g, ' ') || fallback
+  return summary.length > MAX_SUMMARY_LENGTH
+    ? `${summary.slice(0, MAX_SUMMARY_LENGTH - 1).trimEnd()}…`
+    : summary
+}
+
 export default async function Image({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const target = await resolveSlug(id, 'coach')
 
   let name = 'nadamas.app'
   let subtitle = 'Coach de natación'
+  let summary = 'Reserva tus clases de natación y revisa horarios disponibles.'
   let photo: string | null = null
 
   if (target?.kind === 'coach') {
@@ -45,7 +55,8 @@ export default async function Image({ params }: { params: Promise<{ id: string }
     if (detail) {
       name = detail.name
       subtitle = 'Coach de natación'
-      photo = coachDisplayPhoto(detail.coach)
+      summary = coachSummary(detail.coach.bio)
+      photo = coachDisplayPhoto(detail.coach, detail.avatarUrl)
     }
   }
 
@@ -107,7 +118,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
           {subtitle}
         </div>
         <div style={{ fontSize: 30, fontWeight: 500, opacity: 0.8, marginTop: 28 }}>
-          Reserva tus clases de natación
+          {summary}
         </div>
       </div>
     </div>,

--- a/app/(marketing)/[id]/page.tsx
+++ b/app/(marketing)/[id]/page.tsx
@@ -12,6 +12,10 @@ interface PublicProfilePageProps {
 
 const METADATA_BASE = new URL('https://nadamas.app')
 
+function coachDescription(bio?: string) {
+  return bio?.trim() || 'Perfil de coach de natación: estilo, clases y horarios disponibles.'
+}
+
 export async function generateMetadata({ params }: PublicProfilePageProps): Promise<Metadata> {
   const { id } = await params
   const target = await resolveSlug(id, 'coach')
@@ -20,25 +24,32 @@ export async function generateMetadata({ params }: PublicProfilePageProps): Prom
   const detail = await getPublicCoachDetail(target.uid)
   if (!detail) return { title: 'Perfil no disponible' }
   const title = `${detail.name} · Coach de natación`
-  const description =
-    detail.coach.bio || 'Perfil de coach de natación: estilo, clases y horarios disponibles.'
+  const description = coachDescription(detail.coach.bio)
+  const url = `/${id}`
+  const images = [
+    {
+      url: `${url}/opengraph-image`,
+      width: 1200,
+      height: 630,
+      alt: `${detail.name} · Coach de natación`,
+    },
+  ]
 
-  // og:image / twitter:image come from the colocated opengraph-image.tsx
-  // (1200×630 card with the profile photo) — do not set images here.
   return {
     metadataBase: METADATA_BASE,
     title,
     description,
-    alternates: { canonical: `/${id}` },
+    alternates: { canonical: url },
     openGraph: {
       title,
       description,
       type: 'profile',
       siteName: 'nadamas.app',
       locale: 'es_MX',
-      url: `/${id}`,
+      url,
+      images,
     },
-    twitter: { card: 'summary_large_image', title, description },
+    twitter: { card: 'summary_large_image', title, description, images },
   }
 }
 
@@ -64,6 +75,7 @@ export default async function PublicProfilePage({ params }: PublicProfilePagePro
       <CoachPublicProfile
         coach={detail.coach}
         name={detail.name}
+        avatarUrl={detail.avatarUrl}
         bookedSlots={detail.bookedSlots}
         blockedSlots={detail.blockedSlots}
       />


### PR DESCRIPTION
## Summary
- Add explicit Open Graph/Twitter image metadata for public coach slug pages
- Use the coach bio as the share-card summary with a fallback
- Use the coach/avatar display photo in the generated OG image

## Verification
- corepack pnpm typecheck
- corepack pnpm exec biome lint 'app/(marketing)/[id]/page.tsx' 'app/(marketing)/[id]/opengraph-image.tsx'
- git diff --check