### PR TITLE
Use coach photo for share card image

### DIFF
--- a/app/(marketing)/[id]/page.tsx
+++ b/app/(marketing)/[id]/page.tsx
@@ -26,11 +26,10 @@ export async function generateMetadata({ params }: PublicProfilePageProps): Prom
   const title = `${detail.name} · Coach de natación`
   const description = coachDescription(detail.coach.bio)
   const url = `/${id}`
+  const imageUrl = coachDisplayPhoto(detail.coach, detail.avatarUrl) || '/og-nadamas.png'
   const images = [
     {
-      url: `${url}/opengraph-image`,
-      width: 1200,
-      height: 630,
+      url: imageUrl,
       alt: `${detail.name} · Coach de natación`,
     },
   ]


### PR DESCRIPTION
## Summary
- Point public coach page `og:image`/Twitter image directly to the coach display photo
- Keep `/og-nadamas.png` as fallback when a coach has no photo
- Avoid the generated `/[slug]/opengraph-image` route that currently returns 404 in production

## Verification
- corepack pnpm typecheck
- corepack pnpm exec biome lint `app/(marketing)/[id]/page.tsx`
- git diff --check