### PR TITLE
Add calendar feed connections and reminders

### DIFF
--- a/app/(app)/coach/coach-profile/page.tsx
+++ b/app/(app)/coach/coach-profile/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import CalendarConnectionCard from '@comps/calendar/CalendarConnectionCard'
 import LinksCard from '@comps/coach/LinksCard'
 import MediaCard from '@comps/coach/MediaCard'
 import PersonalDataCard from '@comps/coach/PersonalDataCard'
@@ -169,6 +170,8 @@ export default function CoachProfilePage() {
       />
 
       <PublicLinkEditor />
+
+      <CalendarConnectionCard calendarRole="coach" />
 
       <PersonalDataCard
         uid={uid}

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import CalendarConnectionCard from '@comps/calendar/CalendarConnectionCard'
 import { TextField } from '@comps/Inputs/FormFields'
 import PublicLinkEditor from '@comps/profile/PublicLinkEditor'
 import SaveButton from '@comps/SaveButton'
@@ -165,6 +166,8 @@ export default function ProfilePage() {
       </div>
 
       <PublicLinkEditor />
+
+      <CalendarConnectionCard calendarRole="athlete" />
     </div>
   )
 }

--- a/app/api/calendar/connection/route.ts
+++ b/app/api/calendar/connection/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server'
+import {
+  calendarUrlFor,
+  getCalendarFeed,
+  normalizeReminderOffsets,
+  normalizeRole,
+  revokeCalendarFeed,
+  upsertCalendarFeed,
+} from '@/lib/server/calendar-feeds'
+import { adminAuth, adminDb } from '@/lib/server/firebase-admin'
+
+export const runtime = 'nodejs'
+
+function getBearerToken(request: Request) {
+  const match = (request.headers.get('authorization') || '').match(/^Bearer (.+)$/i)
+  return match?.[1] || null
+}
+
+async function requireCaller(request: Request) {
+  const token = getBearerToken(request)
+  if (!token) return null
+  return adminAuth.verifyIdToken(token)
+}
+
+async function canUseRole(uid: string, role: 'athlete' | 'coach') {
+  if (role === 'athlete') return true
+  const userDoc = await adminDb.collection('users').doc(uid).get()
+  const roles = userDoc.data()?.roles || {}
+  return roles.coach === true || roles.admin === true
+}
+
+function connectionPayload(request: Request, feed: Awaited<ReturnType<typeof getCalendarFeed>>) {
+  return {
+    connected: Boolean(feed?.active),
+    role: feed?.role ?? null,
+    reminderOffsets: feed?.reminderOffsets ?? [],
+    calendarUrl: feed?.active ? calendarUrlFor(request, feed.token) : null,
+    updatedAt: feed?.updatedAt ?? null,
+  }
+}
+
+export async function GET(request: Request) {
+  const caller = await requireCaller(request)
+  if (!caller) return NextResponse.json({ error: 'No autenticado.' }, { status: 401 })
+
+  const role = normalizeRole(new URL(request.url).searchParams.get('role'))
+  if (!role) return NextResponse.json({ error: 'Rol inválido.' }, { status: 400 })
+  if (!(await canUseRole(caller.uid, role))) {
+    return NextResponse.json({ error: 'No autorizado.' }, { status: 403 })
+  }
+
+  const feed = await getCalendarFeed(caller.uid, role)
+  return NextResponse.json(connectionPayload(request, feed))
+}
+
+export async function POST(request: Request) {
+  const caller = await requireCaller(request)
+  if (!caller) return NextResponse.json({ error: 'No autenticado.' }, { status: 401 })
+
+  const body = (await request.json().catch(() => ({}))) as {
+    role?: string
+    reminderOffsets?: unknown
+  }
+  const role = normalizeRole(body.role || null)
+  if (!role) return NextResponse.json({ error: 'Rol inválido.' }, { status: 400 })
+  if (!(await canUseRole(caller.uid, role))) {
+    return NextResponse.json({ error: 'No autorizado.' }, { status: 403 })
+  }
+
+  const feed = await upsertCalendarFeed(
+    caller.uid,
+    role,
+    normalizeReminderOffsets(body.reminderOffsets)
+  )
+  return NextResponse.json(connectionPayload(request, feed))
+}
+
+export async function DELETE(request: Request) {
+  const caller = await requireCaller(request)
+  if (!caller) return NextResponse.json({ error: 'No autenticado.' }, { status: 401 })
+
+  const role = normalizeRole(new URL(request.url).searchParams.get('role'))
+  if (!role) return NextResponse.json({ error: 'Rol inválido.' }, { status: 400 })
+  if (!(await canUseRole(caller.uid, role))) {
+    return NextResponse.json({ error: 'No autorizado.' }, { status: 403 })
+  }
+
+  await revokeCalendarFeed(caller.uid, role)
+  return NextResponse.json({ connected: false, role, reminderOffsets: [], calendarUrl: null })
+}

--- a/app/api/calendar/feeds/[token]/route.ts
+++ b/app/api/calendar/feeds/[token]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { buildCalendarIcs, getBookingsForFeed, getFeedByToken } from '@/lib/server/calendar-feeds'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(_request: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params
+  const feed = await getFeedByToken(token)
+  if (!feed) {
+    return new NextResponse('Calendario no encontrado.', {
+      status: 404,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    })
+  }
+
+  const bookings = await getBookingsForFeed(feed)
+  const ics = buildCalendarIcs(feed, bookings)
+
+  return new NextResponse(ics, {
+    headers: {
+      'content-type': 'text/calendar; charset=utf-8',
+      'content-disposition': 'inline; filename="nadamas.ics"',
+      'cache-control': 'no-store, max-age=0',
+    },
+  })
+}

--- a/components/athlete/AthleteHomeDashboard.tsx
+++ b/components/athlete/AthleteHomeDashboard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import CalendarConnectionCard from '@comps/calendar/CalendarConnectionCard'
 import PublicLinkEditor from '@comps/profile/PublicLinkEditor'
 import Link from 'next/link'
 import type React from 'react'
@@ -139,6 +140,8 @@ export default function AthleteHomeDashboard() {
           value={bookings === null ? undefined : coachCount}
         />
       </div>
+
+      <CalendarConnectionCard calendarRole="athlete" />
 
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {ACTION_CARDS.map((card) => {

--- a/components/calendar/CalendarConnectionCard.tsx
+++ b/components/calendar/CalendarConnectionCard.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { FiCalendar, FiCheck, FiCopy, FiExternalLink, FiRefreshCw, FiTrash2 } from 'react-icons/fi'
+import { deleteAuthed, getAuthed, postAuthed } from '@/lib/client/authed-api'
+import { copyTextToClipboard } from '@/lib/client/copy-to-clipboard'
+
+type CalendarRole = 'athlete' | 'coach'
+type ReminderOffset = 5 | 60 | 1440
+type Status = 'idle' | 'loading' | 'saving' | 'error'
+
+interface CalendarConnection {
+  connected: boolean
+  role: CalendarRole | null
+  reminderOffsets: ReminderOffset[]
+  calendarUrl: string | null
+  updatedAt: number | null
+}
+
+const REMINDER_OPTIONS: { value: ReminderOffset; label: string }[] = [
+  { value: 1440, label: '1 día' },
+  { value: 60, label: '1 hora' },
+  { value: 5, label: '5 min' },
+]
+
+const EMPTY_CONNECTION: CalendarConnection = {
+  connected: false,
+  role: null,
+  reminderOffsets: [],
+  calendarUrl: null,
+  updatedAt: null,
+}
+
+function webcalUrl(url: string) {
+  return url.replace(/^https?:\/\//, 'webcal://')
+}
+
+export default function CalendarConnectionCard({ calendarRole }: { calendarRole: CalendarRole }) {
+  const [connection, setConnection] = useState<CalendarConnection>(EMPTY_CONNECTION)
+  const [selectedOffsets, setSelectedOffsets] = useState<ReminderOffset[]>([1440, 60, 5])
+  const [status, setStatus] = useState<Status>('loading')
+  const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setStatus('loading')
+    getAuthed(`/api/calendar/connection?role=${calendarRole}`)
+      .then((response) => response.json() as Promise<CalendarConnection>)
+      .then((payload) => {
+        if (!active) return
+        setConnection(payload)
+        setSelectedOffsets(payload.reminderOffsets.length ? payload.reminderOffsets : [])
+        setStatus('idle')
+      })
+      .catch(() => {
+        if (!active) return
+        setStatus('error')
+        setMessage('No se pudo cargar tu calendario.')
+      })
+    return () => {
+      active = false
+    }
+  }, [calendarRole])
+
+  const links = useMemo(() => {
+    if (!connection.calendarUrl) return null
+    const encodedUrl = encodeURIComponent(connection.calendarUrl)
+    const encodedName = encodeURIComponent(
+      calendarRole === 'coach' ? 'Nadamas - Clases con alumnos' : 'Nadamas - Mis clases'
+    )
+    return {
+      apple: webcalUrl(connection.calendarUrl),
+      google: `https://calendar.google.com/calendar/render?cid=${encodedUrl}`,
+      outlook: `https://outlook.live.com/calendar/0/addcalendar?url=${encodedUrl}&name=${encodedName}`,
+    }
+  }, [connection.calendarUrl, calendarRole])
+
+  async function save(nextOffsets = selectedOffsets) {
+    setStatus('saving')
+    setMessage(null)
+    try {
+      const response = await postAuthed('/api/calendar/connection', {
+        role: calendarRole,
+        reminderOffsets: nextOffsets,
+      })
+      const payload = (await response.json()) as CalendarConnection
+      setConnection(payload)
+      setSelectedOffsets(payload.reminderOffsets)
+      setStatus('idle')
+      setMessage('Calendario actualizado.')
+    } catch {
+      setStatus('error')
+      setMessage('No se pudo actualizar. Intenta de nuevo.')
+    }
+  }
+
+  async function disconnect() {
+    setStatus('saving')
+    setMessage(null)
+    try {
+      await deleteAuthed(`/api/calendar/connection?role=${calendarRole}`)
+      setConnection(EMPTY_CONNECTION)
+      setStatus('idle')
+      setMessage('Calendario desligado.')
+    } catch {
+      setStatus('error')
+      setMessage('No se pudo desligar. Intenta de nuevo.')
+    }
+  }
+
+  function toggleOffset(offset: ReminderOffset) {
+    const next = selectedOffsets.includes(offset)
+      ? selectedOffsets.filter((item) => item !== offset)
+      : [...selectedOffsets, offset].sort((a, b) => b - a)
+    setSelectedOffsets(next)
+    if (connection.connected) void save(next)
+  }
+
+  async function copyLink() {
+    if (!connection.calendarUrl) return
+    try {
+      await copyTextToClipboard(connection.calendarUrl)
+      setMessage('Link copiado.')
+    } catch {
+      setMessage('No se pudo copiar el link.')
+    }
+  }
+
+  const busy = status === 'loading' || status === 'saving'
+  const title =
+    calendarRole === 'coach' ? 'Calendario de clases con alumnos' : 'Calendario de mis clases'
+  const body =
+    calendarRole === 'coach'
+      ? 'Sincroniza solo tus clases reales con alumnos asignados.'
+      : 'Sincroniza tus próximas clases con tus calendarios.'
+
+  return (
+    <section className="rounded-[var(--r-md)] border border-(--c-border) bg-white p-5 shadow-[var(--shadow-sm)]">
+      <div className="flex items-start gap-3">
+        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-full bg-(--c-surface) text-(--c-ocean-mid)">
+          <FiCalendar aria-hidden="true" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="font-bold text-(--c-ocean)">{title}</h2>
+            {connection.connected && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-(--c-border) bg-(--c-surface) px-2 py-0.5 text-xs font-bold text-(--c-aqua-strong)">
+                <FiCheck aria-hidden="true" size={12} />
+                Ligado
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-(--c-text-2)">{body}</p>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <p className="text-xs font-bold uppercase tracking-wide text-(--c-text-2)">Recordatorios</p>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {REMINDER_OPTIONS.map((option) => {
+            const selected = selectedOffsets.includes(option.value)
+            return (
+              <button
+                key={option.value}
+                type="button"
+                disabled={busy}
+                onClick={() => toggleOffset(option.value)}
+                className={`rounded-full border px-3 py-1.5 text-sm font-bold transition disabled:opacity-60 ${
+                  selected
+                    ? 'border-(--c-aqua) bg-(--c-aqua-light) text-(--c-ocean)'
+                    : 'border-(--c-border) bg-white text-(--c-text-2) hover:bg-(--c-surface)'
+                }`}
+              >
+                {option.label}
+              </button>
+            )
+          })}
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => {
+              setSelectedOffsets([])
+              if (connection.connected) void save([])
+            }}
+            className={`rounded-full border px-3 py-1.5 text-sm font-bold transition disabled:opacity-60 ${
+              selectedOffsets.length === 0
+                ? 'border-(--c-aqua) bg-(--c-aqua-light) text-(--c-ocean)'
+                : 'border-(--c-border) bg-white text-(--c-text-2) hover:bg-(--c-surface)'
+            }`}
+          >
+            Ninguno
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        {!connection.connected ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void save()}
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] bg-(--c-ocean) px-4 py-2.5 text-sm font-bold text-white transition hover:opacity-90 disabled:opacity-60"
+          >
+            <FiCalendar aria-hidden="true" />
+            Ligar calendario
+          </button>
+        ) : (
+          <>
+            {links && (
+              <>
+                <a
+                  href={links.apple}
+                  className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] bg-(--c-ocean) px-4 py-2.5 text-sm font-bold text-white transition hover:opacity-90"
+                >
+                  Apple / iOS
+                  <FiExternalLink aria-hidden="true" />
+                </a>
+                <a
+                  href={links.google}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-4 py-2.5 text-sm font-bold text-(--c-ocean) transition hover:bg-(--c-surface)"
+                >
+                  Google
+                  <FiExternalLink aria-hidden="true" />
+                </a>
+                <a
+                  href={links.outlook}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-4 py-2.5 text-sm font-bold text-(--c-ocean) transition hover:bg-(--c-surface)"
+                >
+                  Outlook
+                  <FiExternalLink aria-hidden="true" />
+                </a>
+              </>
+            )}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void copyLink()}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-4 py-2.5 text-sm font-bold text-(--c-ocean) transition hover:bg-(--c-surface) disabled:opacity-60"
+            >
+              <FiCopy aria-hidden="true" />
+              Copiar link
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void save()}
+              aria-label="Actualizar calendario"
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-4 py-2.5 text-sm font-bold text-(--c-ocean) transition hover:bg-(--c-surface) disabled:opacity-60"
+            >
+              <FiRefreshCw aria-hidden="true" />
+              Actualizar
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void disconnect()}
+              aria-label="Desligar calendario"
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] border border-(--rose-bd) bg-white px-4 py-2.5 text-sm font-bold text-(--rose-tx) transition hover:bg-(--rose-bg) disabled:opacity-60"
+            >
+              <FiTrash2 aria-hidden="true" />
+              Desligar
+            </button>
+          </>
+        )}
+      </div>
+
+      {message && (
+        <p className={`mt-3 text-sm ${status === 'error' ? 'text-red-600' : 'text-(--c-text-2)'}`}>
+          {message}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/components/coach/CoachHomeDashboard.tsx
+++ b/components/coach/CoachHomeDashboard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import CalendarConnectionCard from '@comps/calendar/CalendarConnectionCard'
 import CoachOnboardingBanner from '@comps/coach/CoachOnboardingBanner'
 import Link from 'next/link'
 import type React from 'react'
@@ -88,6 +89,8 @@ export default function CoachHomeDashboard() {
         <StatTile icon={<FiUsers aria-hidden="true" />} label="Alumnos" value={stats?.students} />
         <StatTile icon={<FiClock aria-hidden="true" />} label="Horas libres" value={stats?.free} />
       </div>
+
+      <CalendarConnectionCard calendarRole="coach" />
 
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {ACTION_CARDS.map((card) => {

--- a/lib/server/calendar-feeds.ts
+++ b/lib/server/calendar-feeds.ts
@@ -1,0 +1,195 @@
+import 'server-only'
+
+import { randomBytes } from 'node:crypto'
+import type { Booking } from '@/lib/coach-booking'
+import { adminDb } from '@/lib/server/firebase-admin'
+
+export type CalendarRole = 'athlete' | 'coach'
+export type ReminderOffset = 5 | 60 | 1440
+
+export interface CalendarFeed {
+  id: string
+  uid: string
+  role: CalendarRole
+  token: string
+  active: boolean
+  reminderOffsets: ReminderOffset[]
+  createdAt: number
+  updatedAt: number
+  revokedAt?: number | null
+}
+
+const VALID_REMINDERS = new Set<ReminderOffset>([5, 60, 1440])
+
+export function calendarFeedId(uid: string, role: CalendarRole) {
+  return `${uid}_${role}`
+}
+
+export function normalizeRole(value: string | null): CalendarRole | null {
+  return value === 'coach' || value === 'athlete' ? value : null
+}
+
+export function normalizeReminderOffsets(value: unknown): ReminderOffset[] {
+  if (!Array.isArray(value)) return []
+  return [...new Set(value)]
+    .map((item) => Number(item))
+    .filter((item): item is ReminderOffset => VALID_REMINDERS.has(item as ReminderOffset))
+    .sort((a, b) => b - a)
+}
+
+export function calendarUrlFor(request: Request, token: string) {
+  return new URL(`/api/calendar/feeds/${token}.ics`, request.url).toString()
+}
+
+export async function getCalendarFeed(uid: string, role: CalendarRole) {
+  const doc = await adminDb.collection('calendarFeeds').doc(calendarFeedId(uid, role)).get()
+  if (!doc.exists) return null
+  return doc.data() as CalendarFeed
+}
+
+export async function upsertCalendarFeed(
+  uid: string,
+  role: CalendarRole,
+  reminderOffsets: ReminderOffset[]
+) {
+  const ref = adminDb.collection('calendarFeeds').doc(calendarFeedId(uid, role))
+  const current = await ref.get()
+  const now = Date.now()
+  const existing = current.exists ? (current.data() as Partial<CalendarFeed>) : null
+  const feed: CalendarFeed = {
+    id: ref.id,
+    uid,
+    role,
+    token: existing?.token || randomBytes(24).toString('base64url'),
+    active: true,
+    reminderOffsets,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+    revokedAt: null,
+  }
+  await ref.set(feed, { merge: true })
+  return feed
+}
+
+export async function revokeCalendarFeed(uid: string, role: CalendarRole) {
+  const ref = adminDb.collection('calendarFeeds').doc(calendarFeedId(uid, role))
+  await ref.set(
+    {
+      active: false,
+      token: randomBytes(24).toString('base64url'),
+      updatedAt: Date.now(),
+      revokedAt: Date.now(),
+    },
+    { merge: true }
+  )
+}
+
+export async function getFeedByToken(tokenWithExtension: string) {
+  const token = tokenWithExtension.replace(/\.ics$/i, '')
+  const snapshot = await adminDb
+    .collection('calendarFeeds')
+    .where('token', '==', token)
+    .limit(1)
+    .get()
+  if (snapshot.empty) return null
+  const feed = snapshot.docs[0].data() as CalendarFeed
+  return feed.active ? feed : null
+}
+
+export async function getBookingsForFeed(feed: CalendarFeed) {
+  const field = feed.role === 'coach' ? 'coachId' : 'athleteId'
+  const snapshot = await adminDb.collection('bookings').where(field, '==', feed.uid).get()
+  return snapshot.docs
+    .map((doc) => doc.data() as Booking)
+    .filter((booking) => booking.status !== 'cancelled')
+    .filter((booking) => Boolean(booking.athleteId && booking.coachId && booking.date))
+    .sort((a, b) =>
+      `${a.date || ''} ${a.startTime || ''}`.localeCompare(`${b.date || ''} ${b.startTime || ''}`)
+    )
+}
+
+function escapeIcsText(value: string | null | undefined) {
+  return String(value || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;')
+}
+
+function icsDateTime(date: string, time: string) {
+  return `${date.replace(/-/g, '')}T${time.replace(':', '').padEnd(6, '0')}`
+}
+
+function utcStamp(value = new Date()) {
+  return value
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z')
+}
+
+function foldLine(line: string) {
+  const chunks: string[] = []
+  let rest = line
+  while (rest.length > 74) {
+    chunks.push(rest.slice(0, 74))
+    rest = ` ${rest.slice(74)}`
+  }
+  chunks.push(rest)
+  return chunks.join('\r\n')
+}
+
+function eventSummary(feed: CalendarFeed, booking: Booking) {
+  if (feed.role === 'coach') return `Clase con ${booking.athleteName || 'alumno'}`
+  return `Clase con ${booking.coachName || 'coach'}`
+}
+
+function eventDescription(feed: CalendarFeed, booking: Booking) {
+  const counterpart =
+    feed.role === 'coach'
+      ? `Alumno: ${booking.athleteName || 'Alumno'}`
+      : `Coach: ${booking.coachName || 'Coach'}`
+  const modality = booking.groupType === 'grupal' ? 'Clase grupal' : 'Clase individual'
+  return [counterpart, modality, `Ubicación: ${booking.locationName || 'Por confirmar'}`].join('\n')
+}
+
+export function buildCalendarIcs(feed: CalendarFeed, bookings: Booking[]) {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Nadamas//Calendar Feeds//ES',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    `X-WR-CALNAME:${escapeIcsText(feed.role === 'coach' ? 'Nadamas - Clases con alumnos' : 'Nadamas - Mis clases')}`,
+    'X-WR-TIMEZONE:America/Mazatlan',
+    'REFRESH-INTERVAL;VALUE=DURATION:PT1H',
+    'X-PUBLISHED-TTL:PT1H',
+  ]
+
+  for (const booking of bookings) {
+    lines.push(
+      'BEGIN:VEVENT',
+      `UID:${escapeIcsText(`${booking.id}@nadamas.app`)}`,
+      `DTSTAMP:${utcStamp()}`,
+      `DTSTART:${icsDateTime(booking.date, booking.startTime)}`,
+      `DTEND:${icsDateTime(booking.date, booking.endTime || booking.startTime)}`,
+      `SUMMARY:${escapeIcsText(eventSummary(feed, booking))}`,
+      `DESCRIPTION:${escapeIcsText(eventDescription(feed, booking))}`,
+      `LOCATION:${escapeIcsText(booking.locationName || 'Por confirmar')}`,
+      `STATUS:CONFIRMED`,
+      `LAST-MODIFIED:${utcStamp(new Date(booking.updatedAt || booking.createdAt || Date.now()))}`
+    )
+    for (const offset of feed.reminderOffsets) {
+      lines.push(
+        'BEGIN:VALARM',
+        'ACTION:DISPLAY',
+        `DESCRIPTION:${escapeIcsText(eventSummary(feed, booking))}`,
+        `TRIGGER:-PT${offset}M`,
+        'END:VALARM'
+      )
+    }
+    lines.push('END:VEVENT')
+  }
+
+  lines.push('END:VCALENDAR')
+  return `${lines.map(foldLine).join('\r\n')}\r\n`
+}


### PR DESCRIPTION
## Summary
- add authenticated calendar feed connection API for athlete/coach roles
- generate private ICS feeds with booking events and configurable VALARM reminders
- add calendar connection cards to athlete/coach home and profile surfaces with Apple, Google, Outlook, copy, update, and disconnect actions

## Verification
- corepack pnpm typecheck
- corepack pnpm exec biome lint components/calendar/CalendarConnectionCard.tsx lib/server/calendar-feeds.ts app/api/calendar/connection/route.ts 'app/api/calendar/feeds/[token]/route.ts' components/coach/CoachHomeDashboard.tsx components/athlete/AthleteHomeDashboard.tsx 'app/(app)/coach/coach-profile/page.tsx' 'app/(app)/profile/page.tsx'
- git diff --check

## Notes
- corepack pnpm build compiled successfully through TypeScript, then failed while prerendering /terminos because local NEXT_PUBLIC_FIREBASE_CONFIG is unset (JSON.parse(undefined)); this matches the repo env requirement and is not calendar-specific.