### PR TITLE
Add push notification test action

### DIFF
--- a/app/api/push-subscriptions/test/route.ts
+++ b/app/api/push-subscriptions/test/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { adminAuth, adminDb } from '@/lib/server/firebase-admin'
+import { createNotification } from '@/lib/server/notifications'
+
+export const runtime = 'nodejs'
+
+function getBearerToken(request: Request) {
+  const match = (request.headers.get('authorization') || '').match(/^Bearer (.+)$/i)
+  return match?.[1] || null
+}
+
+export async function POST(request: Request) {
+  const token = getBearerToken(request)
+  if (!token) return NextResponse.json({ error: 'No autenticado.' }, { status: 401 })
+
+  const caller = await adminAuth.verifyIdToken(token)
+  const subscriptions = await adminDb
+    .collection('pushSubscriptions')
+    .where('uid', '==', caller.uid)
+    .limit(1)
+    .get()
+
+  if (subscriptions.empty) {
+    return NextResponse.json(
+      { error: 'No hay un dispositivo suscrito para recibir push.' },
+      { status: 409 }
+    )
+  }
+
+  await createNotification({
+    recipientId: caller.uid,
+    actorId: caller.uid,
+    actorName: null,
+    type: 'push_test',
+    title: 'Prueba de notificación',
+    body: 'Si esta alerta llegó fuera de Nadamas, tus avisos push están funcionando.',
+    link: '/notifications',
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/components/notifications/PushNotificationsControl.tsx
+++ b/components/notifications/PushNotificationsControl.tsx
@@ -8,11 +8,14 @@ import {
   subscribeToPushNotifications,
   unsubscribeFromPushNotifications,
 } from '@/lib/client/push-notifications'
+import { postAuthed } from '@/lib/client/authed-api'
 
 type PushState = 'unsupported' | 'off' | 'on' | 'denied' | 'busy'
+type TestState = 'idle' | 'sending' | 'sent' | 'error'
 
 export default function PushNotificationsControl({ compact = false }: { compact?: boolean }) {
   const [state, setState] = useState<PushState>('unsupported')
+  const [testState, setTestState] = useState<TestState>('idle')
 
   useEffect(() => {
     if (!canUsePushNotifications()) {
@@ -34,6 +37,7 @@ export default function PushNotificationsControl({ compact = false }: { compact?
     if (state === 'denied' || state === 'busy') return
     const previous = state
     setState('busy')
+    setTestState('idle')
     try {
       if (previous === 'on') {
         await unsubscribeFromPushNotifications()
@@ -47,38 +51,79 @@ export default function PushNotificationsControl({ compact = false }: { compact?
     }
   }
 
+  const sendTest = async () => {
+    if (state !== 'on' || testState === 'sending') return
+    setTestState('sending')
+    try {
+      await postAuthed('/api/push-subscriptions/test')
+      setTestState('sent')
+    } catch {
+      setTestState('error')
+    }
+  }
+
   const enabled = state === 'on'
   const denied = state === 'denied'
   const label = denied ? 'Bloqueado' : enabled ? 'Desactivar' : 'Activar'
   const icon = enabled ? <FiBellOff aria-hidden="true" /> : <FiBell aria-hidden="true" />
+  const testLabel = testState === 'sending' ? '...' : testState === 'sent' ? 'Enviada' : 'Probar'
 
   if (compact) {
     return (
-      <button
-        type="button"
-        onClick={toggle}
-        disabled={state === 'busy' || denied}
-        aria-label={`${label} avisos`}
-        className="inline-flex h-7 items-center gap-1 rounded-full border border-[var(--c-border)] bg-white px-2 text-[11px] font-bold leading-none text-[var(--c-ocean)] transition hover:bg-[var(--c-surface)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--c-aqua-strong)] disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {state === 'busy' ? '...' : label}
-        <span className="[&_svg]:h-3.5 [&_svg]:w-3.5">{icon}</span>
-      </button>
+      <span className="inline-flex items-center gap-1">
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={state === 'busy' || denied}
+          aria-label={`${label} avisos`}
+          className="inline-flex h-7 items-center gap-1 rounded-full border border-[var(--c-border)] bg-white px-2 text-[11px] font-bold leading-none text-[var(--c-ocean)] transition hover:bg-[var(--c-surface)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--c-aqua-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {state === 'busy' ? '...' : label}
+          <span className="[&_svg]:h-3.5 [&_svg]:w-3.5">{icon}</span>
+        </button>
+        {enabled && (
+          <button
+            type="button"
+            onClick={sendTest}
+            disabled={testState === 'sending'}
+            aria-label="Enviar notificación de prueba"
+            className="inline-flex h-7 items-center rounded-full border border-[var(--c-border)] bg-white px-2 text-[11px] font-bold leading-none text-[var(--c-aqua-strong)] transition hover:bg-[var(--c-surface)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--c-aqua-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {testLabel}
+          </button>
+        )}
+      </span>
     )
   }
 
   return (
-    <button
-      type="button"
-      onClick={toggle}
-      disabled={state === 'busy' || denied}
-      className="flex w-full items-center justify-between gap-3 rounded-[var(--r-sm)] px-3 py-2 text-left text-sm font-semibold text-[var(--c-ocean)] transition hover:bg-[var(--c-surface)] disabled:cursor-not-allowed disabled:opacity-60"
-    >
-      <span className="flex items-center gap-2">
-        {icon}
-        {denied ? 'Permiso bloqueado' : enabled ? 'Desactivar avisos' : 'Activar avisos'}
-      </span>
-      {state === 'busy' && <span className="text-xs text-[var(--c-text-2)]">...</span>}
-    </button>
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={state === 'busy' || denied}
+        className="flex w-full items-center justify-between gap-3 rounded-[var(--r-sm)] px-3 py-2 text-left text-sm font-semibold text-[var(--c-ocean)] transition hover:bg-[var(--c-surface)] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <span className="flex items-center gap-2">
+          {icon}
+          {denied ? 'Permiso bloqueado' : enabled ? 'Desactivar avisos' : 'Activar avisos'}
+        </span>
+        {state === 'busy' && <span className="text-xs text-[var(--c-text-2)]">...</span>}
+      </button>
+      {enabled && (
+        <button
+          type="button"
+          onClick={sendTest}
+          disabled={testState === 'sending'}
+          className="flex w-full items-center justify-between gap-3 rounded-[var(--r-sm)] px-3 py-2 text-left text-sm font-semibold text-[var(--c-aqua-strong)] transition hover:bg-[var(--c-surface)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <span>Enviar prueba</span>
+          <span className="text-xs text-[var(--c-text-2)]">{testLabel}</span>
+        </button>
+      )}
+      {testState === 'error' && (
+        <p className="px-3 text-xs text-red-600">No se pudo enviar la prueba.</p>
+      )}
+    </div>
   )
 }

--- a/lib/notification.ts
+++ b/lib/notification.ts
@@ -5,6 +5,7 @@ export type NotificationType =
   | 'booking_cancelled_by_coach' // coach cancelled -> athlete
   | 'verification_requested' // coach requested -> admins
   | 'verification_reviewed' // admin reviewed -> coach
+  | 'push_test' // user requested a push delivery test
   | 'athlete_invite_accepted' // athlete accepted -> coach (future)
   | 'athlete_invite_rejected' // athlete rejected -> coach (future)
 


### PR DESCRIPTION
## Summary
- add an authenticated endpoint that sends a real push test notification to the current user
- require an existing stored push subscription before reporting success
- add a Probar/Enviar prueba action to the push notification control when avisos are active

## Verification
- corepack pnpm typecheck
- corepack pnpm exec biome lint components/notifications/PushNotificationsControl.tsx app/api/push-subscriptions/test/route.ts lib/notification.ts
- git diff --check