### PR TITLE
Fix PWA push reminders

### DIFF
--- a/app/api/push-subscriptions/test/route.ts
+++ b/app/api/push-subscriptions/test/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
     )
   }
 
-  await createNotification({
+  const notification = await createNotification({
     recipientId: caller.uid,
     actorId: caller.uid,
     actorName: null,
@@ -37,5 +37,13 @@ export async function POST(request: Request) {
     link: '/notifications',
   })
 
-  return NextResponse.json({ ok: true })
+  const pushResult = notification?.pushResult
+  if (!pushResult || pushResult.status !== 'sent') {
+    return NextResponse.json(
+      { error: 'No se pudo enviar la notificación push.', pushResult },
+      { status: 502 }
+    )
+  }
+
+  return NextResponse.json({ ok: true, pushResult })
 }

--- a/components/calendar/CalendarConnectionCard.tsx
+++ b/components/calendar/CalendarConnectionCard.tsx
@@ -38,8 +38,17 @@ function webcalUrl(url: string) {
 export default function CalendarConnectionCard({ calendarRole }: { calendarRole: CalendarRole }) {
   const [connection, setConnection] = useState<CalendarConnection>(EMPTY_CONNECTION)
   const [selectedOffsets, setSelectedOffsets] = useState<ReminderOffset[]>([1440, 60, 5])
+  const [isAppleCalendarPlatform, setIsAppleCalendarPlatform] = useState(false)
   const [status, setStatus] = useState<Status>('loading')
   const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const userAgent = navigator.userAgent || ''
+    const platform = navigator.platform || ''
+    const appleMobile = /iPad|iPhone|iPod/.test(userAgent)
+    const appleDesktop = /Mac/.test(platform) && !/Android|Windows|Linux/.test(userAgent)
+    setIsAppleCalendarPlatform(appleMobile || appleDesktop)
+  }, [])
 
   useEffect(() => {
     let active = true
@@ -208,13 +217,23 @@ export default function CalendarConnectionCard({ calendarRole }: { calendarRole:
           <>
             {links && (
               <>
-                <a
-                  href={links.apple}
-                  className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] bg-(--c-ocean) px-4 py-2.5 text-sm font-bold text-white transition hover:opacity-90"
-                >
-                  Apple / iOS
-                  <FiExternalLink aria-hidden="true" />
-                </a>
+                {isAppleCalendarPlatform ? (
+                  <a
+                    href={links.apple}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[var(--r-sm)] bg-(--c-ocean) px-4 py-2.5 text-sm font-bold text-white transition hover:opacity-90"
+                  >
+                    Apple / iOS
+                    <FiExternalLink aria-hidden="true" />
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    disabled
+                    className="inline-flex min-h-11 cursor-not-allowed items-center justify-center gap-2 rounded-[var(--r-sm)] border border-(--c-border) bg-(--c-surface) px-4 py-2.5 text-sm font-bold text-(--c-text-2) opacity-70"
+                  >
+                    Apple / iOS no disponible
+                  </button>
+                )}
                 <a
                   href={links.google}
                   target="_blank"

--- a/lib/server/notifications.ts
+++ b/lib/server/notifications.ts
@@ -2,7 +2,7 @@ import 'server-only'
 
 import type { AppNotification, NotificationType } from '@/lib/notification'
 import { adminDb } from './firebase-admin'
-import { sendPushNotificationToUser } from './web-push'
+import { type PushSendResult, sendPushNotificationToUser } from './web-push'
 
 interface CreateNotificationInput {
   recipientId: string
@@ -13,6 +13,10 @@ interface CreateNotificationInput {
   body: string
   link: string
   data?: AppNotification['data']
+}
+
+export interface CreateNotificationResult extends AppNotification {
+  pushResult: PushSendResult | null
 }
 
 /**
@@ -38,10 +42,13 @@ export async function createNotification(input: CreateNotificationInput) {
     readAt: null,
   }
   await ref.set(notification)
-  sendPushNotificationToUser(input.recipientId, notification).catch((error) => {
+  let pushResult: PushSendResult | null = null
+  try {
+    pushResult = await sendPushNotificationToUser(input.recipientId, notification)
+  } catch (error) {
     console.error('[WEB_PUSH_SEND]', error)
-  })
-  return notification
+  }
+  return { ...notification, pushResult }
 }
 
 function slotLabel(date?: string, startTime?: string) {

--- a/lib/server/web-push.ts
+++ b/lib/server/web-push.ts
@@ -25,6 +25,19 @@ interface WebPushModule {
   ) => Promise<unknown>
 }
 
+export interface PushSendResult {
+  status: 'sent' | 'skipped' | 'failed'
+  reason?:
+    | 'missing_recipient'
+    | 'manual_recipient'
+    | 'missing_config'
+    | 'missing_library'
+    | 'no_subscriptions'
+  sent: number
+  failed: number
+  removed: number
+}
+
 function getPushConfig() {
   const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
   const privateKey = process.env.VAPID_PRIVATE_KEY
@@ -46,19 +59,28 @@ async function loadWebPush(): Promise<WebPushModule | null> {
 export async function sendPushNotificationToUser(
   uid: string,
   notification: Pick<AppNotification, 'title' | 'body' | 'link' | 'type' | 'data'>
-) {
-  if (!uid || uid.startsWith('manual')) return
+): Promise<PushSendResult> {
+  if (!uid)
+    return { status: 'skipped', reason: 'missing_recipient', sent: 0, failed: 0, removed: 0 }
+  if (uid.startsWith('manual')) {
+    return { status: 'skipped', reason: 'manual_recipient', sent: 0, failed: 0, removed: 0 }
+  }
 
   const config = getPushConfig()
-  if (!config) return
+  if (!config)
+    return { status: 'skipped', reason: 'missing_config', sent: 0, failed: 0, removed: 0 }
 
   const webPush = await loadWebPush()
-  if (!webPush) return
+  if (!webPush) {
+    return { status: 'skipped', reason: 'missing_library', sent: 0, failed: 0, removed: 0 }
+  }
 
   webPush.setVapidDetails(config.subject, config.publicKey, config.privateKey)
 
   const snapshot = await adminDb.collection('pushSubscriptions').where('uid', '==', uid).get()
-  if (snapshot.empty) return
+  if (snapshot.empty) {
+    return { status: 'skipped', reason: 'no_subscriptions', sent: 0, failed: 0, removed: 0 }
+  }
 
   const payload = JSON.stringify({
     title: notification.title,
@@ -70,8 +92,8 @@ export async function sendPushNotificationToUser(
     badge: '/icons/icon_x72.png',
   })
 
-  await Promise.all(
-    snapshot.docs.map(async (doc) => {
+  const results = await Promise.all(
+    snapshot.docs.map(async (doc): Promise<'sent' | 'failed' | 'removed'> => {
       const subscription = doc.data() as StoredPushSubscription
       try {
         await webPush.sendNotification(
@@ -82,13 +104,24 @@ export async function sendPushNotificationToUser(
           },
           payload
         )
+        return 'sent'
       } catch (error) {
         const statusCode =
           typeof error === 'object' && error && 'statusCode' in error
             ? Number((error as { statusCode?: unknown }).statusCode)
             : 0
-        if (statusCode === 404 || statusCode === 410) await doc.ref.delete()
+        if (statusCode === 404 || statusCode === 410) {
+          await doc.ref.delete()
+          return 'removed'
+        }
+        console.error('[WEB_PUSH_SEND_DEVICE]', error)
+        return 'failed'
       }
     })
   )
+
+  const sent = results.filter((result) => result === 'sent').length
+  const failed = results.filter((result) => result === 'failed').length
+  const removed = results.filter((result) => result === 'removed').length
+  return { status: sent > 0 ? 'sent' : 'failed', sent, failed, removed }
 }


### PR DESCRIPTION
## Summary
- Disable the Apple/iOS calendar action on non-Apple platforms so Android users don't see it as the primary selected action.
- Await Web Push delivery before API routes finish, avoiding serverless background sends being dropped.
- Make the push test endpoint fail when no push was actually sent and return delivery diagnostics.

## Verification
- corepack pnpm typecheck
- corepack pnpm exec biome check components/calendar/CalendarConnectionCard.tsx lib/server/web-push.ts lib/server/notifications.ts app/api/push-subscriptions/test/route.ts

## Note
- corepack pnpm build still fails locally at prerendering /terminos with JSON.parse(undefined), which appears to be missing local env/config outside these changes.