### PR TITLE
Improve mobile PWA install flow

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { PHProvider } from './posthog-provider'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://nadamas.app'),
+  manifest: '/manifest.json',
   title: {
     default: 'nadamas.app | Coaches de natación y seguimiento de progreso',
     template: '%s | nadamas.app',
@@ -15,6 +16,23 @@ export const metadata: Metadata = {
   creator: 'nadamas.app',
   publisher: 'nadamas.app',
   formatDetection: { email: false, address: false, telephone: false },
+  icons: {
+    icon: [
+      { url: '/favicon.ico' },
+      { url: '/icons/icon_x192.png', sizes: '192x192', type: 'image/png' },
+      { url: '/icons/icon_x512.png', sizes: '512x512', type: 'image/png' },
+    ],
+    apple: [{ url: '/icons/icon_x192.png', sizes: '192x192', type: 'image/png' }],
+  },
+  appleWebApp: {
+    capable: true,
+    title: 'Nadamas',
+    statusBarStyle: 'default',
+  },
+  other: {
+    'apple-mobile-web-app-title': 'Nadamas',
+    'mobile-web-app-capable': 'yes',
+  },
 }
 
 export const viewport: Viewport = {

--- a/components/app-chrome/AppChrome.tsx
+++ b/components/app-chrome/AppChrome.tsx
@@ -1,5 +1,6 @@
 import type { RoleName } from '@/lib/roles'
 import AppNav from './AppNav'
+import PwaInstallPrompt from './PwaInstallPrompt'
 import ScrollToTop from './ScrollToTop'
 
 export default function AppChrome({
@@ -15,6 +16,7 @@ export default function AppChrome({
     <div data-theme="nadamas" className="min-h-screen bg-[var(--c-bg)] text-[var(--c-ocean)]">
       <ScrollToTop />
       <AppNav role={role} />
+      <PwaInstallPrompt />
       <main className="mx-auto max-w-5xl px-2.5 pb-20 pt-4 sm:px-4 sm:pb-24 sm:pt-6">
         {children}
       </main>

--- a/components/app-chrome/PwaInstallPrompt.tsx
+++ b/components/app-chrome/PwaInstallPrompt.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { FiDownload, FiPlusSquare, FiShare, FiX } from 'react-icons/fi'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>
+}
+
+const DISMISSED_KEY = 'nadamas:pwa-install-dismissed'
+
+function isStandalone() {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone)
+  )
+}
+
+function isMobileDevice() {
+  return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+}
+
+function isIosDevice() {
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent)
+}
+
+export default function PwaInstallPrompt() {
+  const [installEvent, setInstallEvent] = useState<BeforeInstallPromptEvent | null>(null)
+  const [showIosGuide, setShowIosGuide] = useState(false)
+  const [hidden, setHidden] = useState(true)
+
+  useEffect(() => {
+    if (isStandalone() || !isMobileDevice() || localStorage.getItem(DISMISSED_KEY) === '1') return
+
+    if (isIosDevice()) {
+      setShowIosGuide(true)
+      setHidden(false)
+      return
+    }
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault()
+      setInstallEvent(event as BeforeInstallPromptEvent)
+      setHidden(false)
+    }
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+    return () => window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+  }, [])
+
+  if (hidden || (!installEvent && !showIosGuide)) return null
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, '1')
+    setHidden(true)
+  }
+
+  const install = async () => {
+    if (!installEvent) return
+    await installEvent.prompt()
+    const choice = await installEvent.userChoice
+    setInstallEvent(null)
+    if (choice.outcome === 'accepted') setHidden(true)
+  }
+
+  return (
+    <aside className="mx-auto mt-3 max-w-5xl px-3 sm:px-4">
+      <div className="flex items-start gap-3 rounded-[var(--r-sm)] border border-[var(--c-border)] bg-white p-3 text-[var(--c-ocean)] shadow-[var(--shadow-sm)]">
+        <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[var(--c-aqua-light)] text-[var(--c-ocean)]">
+          <FiDownload aria-hidden="true" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-bold">Instala Nadamas</p>
+          {showIosGuide ? (
+            <p className="mt-0.5 flex flex-wrap items-center gap-1.5 text-xs text-[var(--c-text-2)]">
+              <span>Toca</span>
+              <FiShare aria-hidden="true" className="h-3.5 w-3.5 text-[var(--c-ocean)]" />
+              <span>y luego</span>
+              <FiPlusSquare aria-hidden="true" className="h-3.5 w-3.5 text-[var(--c-ocean)]" />
+              <span>Agregar a inicio.</span>
+            </p>
+          ) : (
+            <p className="mt-0.5 text-xs text-[var(--c-text-2)]">
+              Accede más rápido y recibe avisos como app.
+            </p>
+          )}
+        </div>
+        {installEvent && (
+          <button
+            type="button"
+            onClick={() => void install()}
+            className="inline-flex min-h-9 shrink-0 items-center justify-center rounded-[var(--r-sm)] bg-[var(--c-ocean)] px-3 text-xs font-bold text-white"
+          >
+            Instalar
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Ocultar instalación"
+          className="grid h-9 w-9 shrink-0 place-items-center rounded-full text-[var(--c-text-2)] transition hover:bg-[var(--c-surface)] hover:text-[var(--c-ocean)]"
+        >
+          <FiX aria-hidden="true" />
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,13 +1,17 @@
 {
-  "name": "nadamas.app",
-  "short_name": "nadamas",
-  "description": "Encuentra y reserva coaches de natación. Aprende, mejora y entrena.",
+  "id": "/",
+  "name": "Nadamas",
+  "short_name": "Nadamas",
+  "description": "Reserva clases de natación y da seguimiento a tu progreso.",
+  "lang": "es-MX",
   "theme_color": "#0A2540",
   "background_color": "#F8FAFC",
   "display": "standalone",
+  "display_override": ["standalone", "minimal-ui"],
   "orientation": "portrait",
   "scope": "/",
-  "start_url": "/dashboard",
+  "start_url": "/dashboard?source=pwa",
+  "categories": ["sports", "health", "education"],
   "prefer_related_applications": false,
   "icons": [
     {


### PR DESCRIPTION
## Summary
- Set explicit manifest and Apple web app metadata so iOS suggests the app name Nadamas instead of a long SEO page title.
- Tighten the PWA manifest with id, lang, install categories, display_override, and a PWA-specific start URL.
- Add a mobile install prompt inside the app shell: Chromium uses beforeinstallprompt; iOS gets a small install guide because Safari requires manual Add to Home Screen.

## Verification
- corepack pnpm typecheck
- corepack pnpm exec biome check app/layout.tsx components/app-chrome/AppChrome.tsx components/app-chrome/PwaInstallPrompt.tsx public/manifest.json