### PR TITLE
Simplify student progress capture to 3-click scale

### DIFF
--- a/CONSTANTS/PROGRESS_SCALE.ts
+++ b/CONSTANTS/PROGRESS_SCALE.ts
@@ -1,0 +1,30 @@
+export interface ProgressScaleOption {
+  value: number
+  label: string
+  emoji?: string
+}
+
+export const PROGRESS_LEVELS: ProgressScaleOption[] = [
+  { value: 1, label: '1' },
+  { value: 2, label: '2' },
+  { value: 3, label: '3' },
+  { value: 4, label: '4' },
+]
+
+export const PROGRESS_SUBLEVELS: ProgressScaleOption[] = [
+  { value: 1, label: '1' },
+  { value: 2, label: '2' },
+  { value: 3, label: '3' },
+  { value: 4, label: '4' },
+]
+
+export const PROGRESS_RESULTS: Required<ProgressScaleOption>[] = [
+  { value: 1, label: 'Triste', emoji: '😢' },
+  { value: 2, label: 'Enojado', emoji: '😠' },
+  { value: 3, label: 'Neutro', emoji: '😐' },
+  { value: 4, label: 'Feliz', emoji: '😊' },
+]
+
+export function progressResultEmoji(value: number | undefined) {
+  return PROGRESS_RESULTS.find((item) => item.value === value)?.emoji || ''
+}

--- a/app/(app)/athlete/progress/page.tsx
+++ b/app/(app)/athlete/progress/page.tsx
@@ -4,10 +4,11 @@ import Loading from '@comps/Loading'
 import Avatar from '@comps/ui/avatar'
 import type React from 'react'
 import { useEffect, useState } from 'react'
-import { FiCalendar, FiMapPin, FiTarget, FiTrendingUp, FiUsers } from 'react-icons/fi'
+import { FiCalendar, FiMapPin, FiTrendingUp, FiUsers } from 'react-icons/fi'
+import { progressResultEmoji } from '@/CONSTANTS/PROGRESS_SCALE'
 import { getAuthed } from '@/lib/client/authed-api'
 import type { Booking } from '@/lib/coach-booking'
-import type { StudentProgress } from '@/lib/coach-student-progress'
+import { clampScale, formatStudentLevel, type StudentProgress } from '@/lib/coach-student-progress'
 import { GENERIC_USER_ERROR, reportInternalError } from '@/lib/user-facing-error'
 
 export default function ProgressPage() {
@@ -36,8 +37,9 @@ export default function ProgressPage() {
 
   const avgAssessment = progress.length
     ? `${Math.round(
-        progress.reduce((total, item) => total + item.coachAssessment, 0) / progress.length
-      )}/5`
+        progress.reduce((total, item) => total + clampScale(item.coachAssessment, 1), 0) /
+          progress.length
+      )}/4`
     : '—'
 
   return (
@@ -98,31 +100,15 @@ export default function ProgressPage() {
                     <Avatar name={coachName} size={42} />
                     <div className="min-w-0 flex-1">
                       <p className="truncate font-bold text-(--c-ocean)">{coachName}</p>
-                      <p className="mt-0.5 text-sm text-(--c-text-2)">Nivel: {item.level}</p>
+                      <p className="mt-0.5 text-sm text-(--c-text-2)">
+                        Nivel {formatStudentLevel(item)}
+                      </p>
                     </div>
                     <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-(--c-surface) px-3 py-1 text-sm font-semibold text-(--c-ocean)">
-                      <FiTrendingUp aria-hidden="true" />
-                      {item.coachAssessment}/5
+                      {progressResultEmoji(item.result) || <FiTrendingUp aria-hidden="true" />}
+                      {formatStudentLevel(item)}
                     </span>
                   </div>
-                  {(item.goal || item.nextFocus) && (
-                    <div className="mt-4 grid gap-3 md:grid-cols-2">
-                      {item.goal && (
-                        <ProgressNote
-                          icon={<FiTarget aria-hidden="true" />}
-                          label="Objetivo"
-                          text={item.goal}
-                        />
-                      )}
-                      {item.nextFocus && (
-                        <ProgressNote
-                          icon={<FiCalendar aria-hidden="true" />}
-                          label="Próximo foco"
-                          text={item.nextFocus}
-                        />
-                      )}
-                    </div>
-                  )}
                   {item.lastNote && (
                     <p className="mt-4 rounded-[var(--r-sm)] bg-(--c-surface) p-4 text-sm leading-6 text-(--c-text-2)">
                       {item.lastNote}
@@ -199,26 +185,6 @@ function StatTile({
         {value === undefined ? '—' : value}
       </span>
       <span className="text-xs font-semibold text-(--c-text-2)">{label}</span>
-    </div>
-  )
-}
-
-function ProgressNote({
-  icon,
-  label,
-  text,
-}: {
-  icon: React.ReactNode
-  label: string
-  text: string
-}) {
-  return (
-    <div className="flex gap-3 rounded-[var(--r-sm)] border border-(--c-border) p-3">
-      <span className="mt-0.5 text-(--c-ocean-mid)">{icon}</span>
-      <div>
-        <p className="text-xs font-bold uppercase text-(--c-text-2)">{label}</p>
-        <p className="mt-1 text-sm text-(--c-ocean)">{text}</p>
-      </div>
     </div>
   )
 }

--- a/app/(app)/athlete/progress/page.tsx
+++ b/app/(app)/athlete/progress/page.tsx
@@ -47,7 +47,7 @@ export default function ProgressPage() {
       <header>
         <h1 className="text-3xl font-extrabold text-(--c-ocean)">Mi progreso</h1>
         <p className="mt-1 text-(--c-text-2)">
-          Historial de clases, objetivos y seguimiento de tus coaches.
+          Historial de clases y seguimiento de tus coaches.
         </p>
       </header>
 

--- a/app/api/coach/agenda/bookings/route.ts
+++ b/app/api/coach/agenda/bookings/route.ts
@@ -137,11 +137,9 @@ export async function POST(request: Request) {
       athleteName: booking.athleteName,
       athleteEmail: booking.athleteEmail ?? null,
       ...(booking.athletePhone ? { athletePhone: booking.athletePhone } : {}),
-      level: 'Inicial',
-      goal: '',
-      lastNote: '',
-      nextFocus: '',
+      level: 1,
       coachAssessment: 1,
+      lastNote: '',
       createdAt: now,
       updatedAt: now,
     }

--- a/app/api/coach/students/route.ts
+++ b/app/api/coach/students/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import type { Booking } from '@/lib/coach-booking'
 import {
   clampScale,
+  computeStudentPosition,
   normalizeLevelValue,
   normalizeStudentProgressInput,
   type StudentProgress,
@@ -302,6 +303,30 @@ export async function PATCH(request: Request) {
   const docRef = adminDb.collection('coachStudentProgress').doc(id)
   const current = existingProgress
   const normalized = normalizeStudentProgressInput(body)
+
+  // Append a timestamped entry to the student's progress history.
+  const entryRef = adminDb.collection('coachStudentProgressEntries').doc()
+  const entry: StudentProgressEntry = {
+    id: entryRef.id,
+    coachId,
+    athleteId: body.athleteId,
+    level: normalized.level,
+    coachAssessment: normalized.coachAssessment,
+    result: normalized.result,
+    note: normalized.lastNote,
+    createdAt: now,
+  }
+
+  // The doc's level is not the last click but the rounded-up average of the
+  // most recent entries (including this one).
+  const historySnapshot = await adminDb
+    .collection('coachStudentProgressEntries')
+    .where('coachId', '==', coachId)
+    .where('athleteId', '==', body.athleteId)
+    .get()
+  const history = historySnapshot.docs.map((doc) => doc.data() as StudentProgressEntry)
+  const computed = computeStudentPosition([...history, entry])
+
   const progress: StudentProgress = {
     id,
     coachId,
@@ -315,19 +340,7 @@ export async function PATCH(request: Request) {
     createdAt: (current.data()?.createdAt as number | undefined) || now,
     updatedAt: now,
     ...normalized,
-  }
-
-  // Append a timestamped entry to the student's progress history.
-  const entryRef = adminDb.collection('coachStudentProgressEntries').doc()
-  const entry: StudentProgressEntry = {
-    id: entryRef.id,
-    coachId,
-    athleteId: body.athleteId,
-    level: normalized.level,
-    coachAssessment: normalized.coachAssessment,
-    result: normalized.result,
-    note: normalized.lastNote,
-    createdAt: now,
+    ...computed,
   }
 
   await Promise.all([docRef.set(progress, { merge: true }), entryRef.set(entry)])

--- a/app/api/coach/students/route.ts
+++ b/app/api/coach/students/route.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto'
 import { NextResponse } from 'next/server'
 import type { Booking } from '@/lib/coach-booking'
 import {
+  clampScale,
+  normalizeLevelValue,
   normalizeStudentProgressInput,
   type StudentProgress,
   type StudentProgressEntry,
@@ -158,11 +160,9 @@ export async function POST(request: Request) {
     athleteName: name,
     athleteEmail: email || null,
     ...(phone ? { athletePhone: phone } : {}),
-    level: 'Inicial',
-    goal: '',
-    lastNote: '',
-    nextFocus: '',
+    level: 1,
     coachAssessment: 1,
+    lastNote: '',
     createdAt: now,
     updatedAt: now,
   }
@@ -232,11 +232,11 @@ export async function PUT(request: Request) {
     athletePhone: details.phone,
     athleteAddress: details.address,
     athleteLocation: details.location,
-    level: current?.level || 'Inicial',
-    goal: current?.goal || '',
+    level: normalizeLevelValue(current?.level),
+    coachAssessment: clampScale(current?.coachAssessment, 1),
+    // Firestore rejects `undefined`; only include result when the doc has one.
+    ...(current?.result ? { result: current.result } : {}),
     lastNote: current?.lastNote || '',
-    nextFocus: current?.nextFocus || '',
-    coachAssessment: current?.coachAssessment || 1,
     createdAt: current?.createdAt || now,
     updatedAt: now,
   }
@@ -325,8 +325,7 @@ export async function PATCH(request: Request) {
     athleteId: body.athleteId,
     level: normalized.level,
     coachAssessment: normalized.coachAssessment,
-    goal: normalized.goal,
-    nextFocus: normalized.nextFocus,
+    result: normalized.result,
     note: normalized.lastNote,
     createdAt: now,
   }

--- a/components/coach/CoachStudents.tsx
+++ b/components/coach/CoachStudents.tsx
@@ -18,9 +18,14 @@ import {
   FiSearch,
   FiTrendingUp,
 } from 'react-icons/fi'
+import { progressResultEmoji } from '@/CONSTANTS/PROGRESS_SCALE'
 import { getAuthed } from '@/lib/client/authed-api'
 import type { Booking } from '@/lib/coach-booking'
-import type { StudentProgress, StudentProgressEntry } from '@/lib/coach-student-progress'
+import {
+  formatStudentLevel,
+  type StudentProgress,
+  type StudentProgressEntry,
+} from '@/lib/coach-student-progress'
 import { GENERIC_USER_ERROR, reportInternalError } from '@/lib/user-facing-error'
 import AddStudentModal, { type CreatedStudentPayload } from './AddStudentModal'
 import EditStudentModal, { type UpdatedStudentPayload } from './EditStudentModal'
@@ -223,8 +228,7 @@ function StudentCard({
     }
   }, [focused])
 
-  const level = student.progress?.level || 'Inicial'
-  const assessment = student.progress?.coachAssessment
+  const level = student.progress ? formatStudentLevel(student.progress) : '1.1'
   const summary = `${student.totalClasses} ${student.totalClasses === 1 ? 'clase' : 'clases'} · Nivel ${level}`
   const visibleEntries = showAll ? student.entries : student.entries.slice(0, ENTRY_PREVIEW)
 
@@ -310,8 +314,8 @@ function StudentCard({
             />
             <MetricPill
               icon={<FiTrendingUp aria-hidden="true" />}
-              label="Avance"
-              value={assessment ? `${assessment}/5` : '—'}
+              label="Nivel"
+              value={student.progress ? formatStudentLevel(student.progress) : '—'}
             />
           </div>
 
@@ -395,6 +399,7 @@ function isWebUrl(value: string) {
 
 function EntryItem({ entry }: { entry: StudentProgressEntry }) {
   const [open, setOpen] = useState(false)
+  const emoji = progressResultEmoji(entry.result)
   const date = new Date(entry.createdAt).toLocaleDateString('es-MX', {
     day: 'numeric',
     month: 'short',
@@ -413,38 +418,24 @@ function EntryItem({ entry }: { entry: StudentProgressEntry }) {
           <div className="flex items-center justify-between gap-2">
             <span className="text-sm font-bold text-(--c-ocean)">{date}</span>
             <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-(--c-surface) px-2.5 py-0.5 text-xs font-semibold text-(--c-ocean)">
-              {entry.level} · {entry.coachAssessment}/5
+              {formatStudentLevel(entry)}
+              {emoji && <span aria-hidden="true">· {emoji}</span>}
             </span>
           </div>
-          <div className="mt-2 grid grid-cols-2 gap-3">
-            <DetailCol label="Objetivo" text={entry.goal} truncate={!open} />
-            <DetailCol label="Próximo foco" text={entry.nextFocus} truncate={!open} />
-          </div>
+          {entry.note && (
+            <p
+              className={`mt-2 text-sm text-(--c-text-2) ${open ? 'whitespace-pre-wrap' : 'truncate'}`}
+            >
+              {entry.note}
+            </p>
+          )}
         </div>
         <FiChevronDown
           aria-hidden="true"
           className={`mt-0.5 shrink-0 text-(--c-ocean-mid) transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>
-
-      {open && entry.note && (
-        <div className="px-3 pb-3">
-          <p className="text-[10px] font-bold uppercase tracking-wide text-(--c-text-2)">Nota</p>
-          <p className="mt-1 whitespace-pre-wrap text-sm text-(--c-ocean)">{entry.note}</p>
-        </div>
-      )}
     </li>
-  )
-}
-
-function DetailCol({ label, text, truncate }: { label: string; text: string; truncate: boolean }) {
-  return (
-    <div className="min-w-0">
-      <p className="text-[10px] font-bold uppercase tracking-wide text-(--c-text-2)">{label}</p>
-      <p className={`text-sm text-(--c-ocean) ${truncate ? 'truncate' : 'whitespace-pre-wrap'}`}>
-        {text || '—'}
-      </p>
-    </div>
   )
 }
 

--- a/components/coach/StudentProgressModal.tsx
+++ b/components/coach/StudentProgressModal.tsx
@@ -2,10 +2,16 @@
 
 import { useKeyboardSafeArea } from '@comps/hooks/useKeyboardSafeArea'
 import { useState } from 'react'
+import {
+  PROGRESS_LEVELS,
+  PROGRESS_RESULTS,
+  PROGRESS_SUBLEVELS,
+  type ProgressScaleOption,
+} from '@/CONSTANTS/PROGRESS_SCALE'
 import { patchAuthed } from '@/lib/client/authed-api'
 import {
-  STUDENT_LEVELS,
-  type StudentLevel,
+  clampScale,
+  normalizeLevelValue,
   type StudentProgress,
   type StudentProgressEntry,
 } from '@/lib/coach-student-progress'
@@ -25,24 +31,23 @@ export default function StudentProgressModal({
   onSaved: (entry: StudentProgressEntry, progress: StudentProgress) => void
 }) {
   // Level/avance carry the student's current state as a starting point; the
-  // session text fields start blank so each entry is a fresh log.
-  const [level, setLevel] = useState<StudentLevel>(initial?.level || 'Inicial')
-  const [coachAssessment, setCoachAssessment] = useState(initial?.coachAssessment || 1)
-  const [goal, setGoal] = useState('')
-  const [nextFocus, setNextFocus] = useState('')
+  // session result starts unselected because it grades this session only.
+  const [level, setLevel] = useState(() => normalizeLevelValue(initial?.level))
+  const [subLevel, setSubLevel] = useState(() => clampScale(initial?.coachAssessment, 1))
+  const [result, setResult] = useState<number | null>(null)
   const [note, setNote] = useState('')
   const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle')
   const keyboardSafeArea = useKeyboardSafeArea()
 
   async function save() {
+    if (result === null) return
     setStatus('saving')
     try {
       const response = await patchAuthed('/api/coach/students', {
         athleteId,
         level,
-        coachAssessment,
-        goal,
-        nextFocus,
+        coachAssessment: subLevel,
+        result,
         lastNote: note,
       })
       const payload = (await response.json()) as {
@@ -77,62 +82,28 @@ export default function StudentProgressModal({
           <p className="mt-0.5 text-sm text-(--c-text-2)">{studentName}</p>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_9rem]">
-          <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
-            Nivel
-            <select
-              value={level}
-              onChange={(event) => setLevel(event.target.value as StudentLevel)}
-              className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
-            >
-              {STUDENT_LEVELS.map((item) => (
-                <option key={item} value={item}>
-                  {item}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
-            Avance
-            <input
-              type="number"
-              min="1"
-              max="5"
-              value={coachAssessment}
-              onChange={(event) => setCoachAssessment(Number(event.target.value))}
-              className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
-            />
-          </label>
-        </div>
+        <ScaleRow label="Nivel" options={PROGRESS_LEVELS} selected={level} onSelect={setLevel} />
+        <ScaleRow
+          label="Avance"
+          options={PROGRESS_SUBLEVELS}
+          selected={subLevel}
+          onSelect={setSubLevel}
+        />
+        <ScaleRow
+          label="Resultado"
+          options={PROGRESS_RESULTS}
+          selected={result}
+          onSelect={setResult}
+        />
 
         <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
-          Objetivo
-          <input
-            value={goal}
-            onChange={(event) => setGoal(event.target.value)}
-            maxLength={240}
-            placeholder="Ej. mejorar respiración bilateral"
-            className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
-          />
-        </label>
-        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
-          Próximo foco
-          <input
-            value={nextFocus}
-            onChange={(event) => setNextFocus(event.target.value)}
-            maxLength={240}
-            placeholder="Ej. salida y patada constante"
-            className="min-h-11 rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 text-sm text-(--c-ocean)"
-          />
-        </label>
-        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
-          Nota de la sesión
+          Nota (opcional)
           <textarea
             value={note}
             onChange={(event) => setNote(event.target.value)}
             maxLength={800}
-            rows={3}
-            placeholder="Observaciones de técnica, asistencia o tareas para la siguiente clase."
+            rows={2}
+            placeholder="Observaciones de la sesión."
             className="rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 py-2 text-sm text-(--c-ocean)"
           />
         </label>
@@ -145,7 +116,7 @@ export default function StudentProgressModal({
           <button
             type="button"
             onClick={save}
-            disabled={status === 'saving'}
+            disabled={status === 'saving' || result === null}
             className="min-h-12 rounded-full bg-(--c-ocean) font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-60"
           >
             {status === 'saving' ? 'Guardando…' : 'Guardar progreso'}
@@ -160,5 +131,54 @@ export default function StudentProgressModal({
         </div>
       </div>
     </div>
+  )
+}
+
+function ScaleRow({
+  label,
+  options,
+  selected,
+  onSelect,
+}: {
+  label: string
+  options: ProgressScaleOption[]
+  selected: number | null
+  onSelect: (value: number) => void
+}) {
+  return (
+    <fieldset className="grid gap-1.5">
+      <legend className="text-sm font-semibold text-(--c-ocean)">{label}</legend>
+      <div role="radiogroup" aria-label={label} className="grid grid-cols-4 gap-2">
+        {options.map((option) => {
+          const active = option.value === selected
+          return (
+            // biome-ignore lint/a11y/useSemanticElements: styled toggle button, not a native radio input
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onSelect(option.value)}
+              className={`flex min-h-12 flex-col items-center justify-center rounded-[var(--r-sm)] border text-sm font-bold transition-colors ${
+                active
+                  ? 'border-(--c-ocean) bg-(--c-ocean) text-white'
+                  : 'border-(--c-border) bg-white text-(--c-ocean) hover:bg-(--c-surface)'
+              }`}
+            >
+              {option.emoji ? (
+                <>
+                  <span aria-hidden="true" className="text-xl leading-none">
+                    {option.emoji}
+                  </span>
+                  <span className="mt-0.5 text-[10px] font-semibold">{option.label}</span>
+                </>
+              ) : (
+                option.label
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </fieldset>
   )
 }

--- a/docs/superpowers/plans/2026-07-17-simplified-student-progress.md
+++ b/docs/superpowers/plans/2026-07-17-simplified-student-progress.md
@@ -1,0 +1,652 @@
+# Simplified Student Progress Capture — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Registrar progreso de un alumno en 3 clicks (Nivel 1–4, Avance 1–4, Resultado 1–4 con emoji) + nota opcional, reemplazando el formulario de 5 campos.
+
+**Architecture:** Se reusa el schema Firestore actual (`coachStudentProgress` / `coachStudentProgressEntries`). `level` pasa de string a número con mapeo legacy en lectura; `coachAssessment` se mantiene como nombre de campo para el subnivel (clamp 1–4); se agrega `result`. La escala (labels/emojis) vive en `CONSTANTS/PROGRESS_SCALE.ts` y la UI solo consume esas constantes.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Firebase Admin (API routes), TypeScript strict, Tailwind v4, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-simplified-student-progress-design.md`
+
+## Global Constraints
+
+- No hay unit test runner en el repo; la verificación por task es `pnpm typecheck` + `pnpm check`, y verificación manual del flujo al final (emulator).
+- Errores de UI: nunca exponer `error.message`; usar `reportInternalError` + `GENERIC_USER_ERROR` (ya lo hace el modal).
+- Copy de UI en español; código y rutas en inglés.
+- Campo persistido del subnivel se llama `coachAssessment` — NO renombrar.
+- Mapeo legacy: `Inicial→1, Básico→2, Intermedio→3, Avanzado→4, Competitivo→4`.
+- `result` es opcional en los tipos (entries viejos no lo tienen); ausente = no se muestra emoji.
+- Formato visual de posición: `nivel.subnivel` (ej. `3.2`).
+
+---
+
+### Task 1: Escala en CONSTANTS y modelo/normalizador en lib
+
+**Files:**
+- Create: `CONSTANTS/PROGRESS_SCALE.ts`
+- Modify: `lib/coach-student-progress.ts` (rewrite completo)
+
+**Interfaces:**
+- Produces (consumido por Tasks 2–4):
+  - `PROGRESS_LEVELS`, `PROGRESS_SUBLEVELS`: `{ value: number; label: string }[]`
+  - `PROGRESS_RESULTS`: `{ value: number; label: string; emoji: string }[]`
+  - `progressResultEmoji(value: number | undefined): string` (`''` si no hay match)
+  - `normalizeLevelValue(value: unknown): number` — string legacy o número → 1–4 (default 1)
+  - `clampScale(value: unknown, fallback: number): number` — 1–4
+  - `formatStudentLevel(item: { level: unknown; coachAssessment: unknown }): string` — `"3.2"`
+  - `normalizeStudentProgressInput(input): { level: number; coachAssessment: number; result: number; lastNote: string }`
+  - Tipos `StudentProgress`, `StudentProgressEntry` (con `level: number`, `result?: number`, sin `goal`/`nextFocus`), `StudentProgressInput`
+  - `studentProgressId(coachId, athleteId)` sin cambios
+
+- [ ] **Step 1: Crear `CONSTANTS/PROGRESS_SCALE.ts`**
+
+```ts
+export interface ProgressScaleOption {
+  value: number
+  label: string
+  emoji?: string
+}
+
+export const PROGRESS_LEVELS: ProgressScaleOption[] = [
+  { value: 1, label: '1' },
+  { value: 2, label: '2' },
+  { value: 3, label: '3' },
+  { value: 4, label: '4' },
+]
+
+export const PROGRESS_SUBLEVELS: ProgressScaleOption[] = [
+  { value: 1, label: '1' },
+  { value: 2, label: '2' },
+  { value: 3, label: '3' },
+  { value: 4, label: '4' },
+]
+
+export const PROGRESS_RESULTS: Required<ProgressScaleOption>[] = [
+  { value: 1, label: 'Triste', emoji: '😢' },
+  { value: 2, label: 'Enojado', emoji: '😠' },
+  { value: 3, label: 'Neutro', emoji: '😐' },
+  { value: 4, label: 'Feliz', emoji: '😊' },
+]
+
+export function progressResultEmoji(value: number | undefined) {
+  return PROGRESS_RESULTS.find((item) => item.value === value)?.emoji || ''
+}
+```
+
+- [ ] **Step 2: Reescribir `lib/coach-student-progress.ts`**
+
+Contenido completo del archivo:
+
+```ts
+/** Legacy string levels stored before the numeric 1-4 scale. */
+const LEGACY_LEVEL_MAP: Record<string, number> = {
+  Inicial: 1,
+  Básico: 2,
+  Intermedio: 3,
+  Avanzado: 4,
+  Competitivo: 4,
+}
+
+export interface StudentProgress {
+  id: string
+  coachId: string
+  athleteId: string
+  athleteName: string
+  athleteEmail: string | null
+  athletePhone?: string
+  athleteAddress?: string
+  athleteLocation?: string
+  /** 1-4. Legacy docs may still hold a string; normalize with normalizeLevelValue. */
+  level: number
+  /** Sub-level 1-4 (field name kept for data compatibility). */
+  coachAssessment: number
+  /** Last session result 1-4; absent on docs saved before this field existed. */
+  result?: number
+  lastNote: string
+  createdAt: number
+  updatedAt: number
+}
+
+export interface StudentProgressInput {
+  level?: unknown
+  coachAssessment?: unknown
+  result?: unknown
+  lastNote?: unknown
+}
+
+/** One timestamped progress record in a student's history. */
+export interface StudentProgressEntry {
+  id: string
+  coachId: string
+  athleteId: string
+  level: number
+  coachAssessment: number
+  result?: number
+  note: string
+  createdAt: number
+}
+
+export function studentProgressId(coachId: string, athleteId: string) {
+  return `${coachId}_${athleteId}`
+}
+
+export function clampScale(value: unknown, fallback: number) {
+  const score = Number(value)
+  if (!Number.isFinite(score)) return fallback
+  return Math.min(4, Math.max(1, Math.round(score)))
+}
+
+export function normalizeLevelValue(value: unknown): number {
+  if (typeof value === 'string' && value in LEGACY_LEVEL_MAP) return LEGACY_LEVEL_MAP[value]
+  return clampScale(value, 1)
+}
+
+/** Renders the combined position, e.g. level 3 + sub-level 2 -> "3.2". */
+export function formatStudentLevel(item: { level: unknown; coachAssessment: unknown }) {
+  return `${normalizeLevelValue(item.level)}.${clampScale(item.coachAssessment, 1)}`
+}
+
+export function normalizeStudentProgressInput(input: StudentProgressInput) {
+  return {
+    level: normalizeLevelValue(input.level),
+    coachAssessment: clampScale(input.coachAssessment, 1),
+    result: clampScale(input.result, 3),
+    lastNote: limitText(input.lastNote, 800),
+  }
+}
+
+function limitText(value: unknown, max: number) {
+  return typeof value === 'string' ? value.trim().slice(0, max) : ''
+}
+```
+
+Nota: `STUDENT_LEVELS`, `StudentLevel` y los campos `goal`/`nextFocus` desaparecen a propósito. El typecheck fallará en los consumidores hasta terminar Tasks 2–4 — esperado; NO commitear todavía.
+
+- [ ] **Step 3: Verificar que typecheck falla solo en los consumidores esperados**
+
+Run: `pnpm typecheck`
+Expected: errores SOLO en `app/api/coach/students/route.ts`, `app/api/coach/agenda/bookings/route.ts`, `components/coach/StudentProgressModal.tsx`, `components/coach/CoachStudents.tsx`, `app/(app)/athlete/progress/page.tsx`. Cualquier otro archivo con error = consumidor no mapeado; revisar antes de seguir.
+
+(No commit en esta task; se commitea al final de Task 2 cuando el typecheck pasa.)
+
+---
+
+### Task 2: API routes
+
+**Files:**
+- Modify: `app/api/coach/students/route.ts` (POST líneas ~154–168, PUT ~226–242, PATCH ~304–332)
+- Modify: `app/api/coach/agenda/bookings/route.ts` (~133–147)
+
+**Interfaces:**
+- Consumes (Task 1): `normalizeStudentProgressInput`, `normalizeLevelValue`, `clampScale`, tipos nuevos.
+- Produces: PATCH `/api/coach/students` responde `{ progress, entry }` donde `entry` incluye `result: number` y ya no incluye `goal`/`nextFocus`.
+
+- [ ] **Step 1: `app/api/coach/students/route.ts` — actualizar imports**
+
+```ts
+import {
+  clampScale,
+  normalizeLevelValue,
+  normalizeStudentProgressInput,
+  type StudentProgress,
+  type StudentProgressEntry,
+  type StudentProgressInput,
+  studentProgressId,
+} from '@/lib/coach-student-progress'
+```
+
+- [ ] **Step 2: POST — defaults del doc nuevo (líneas ~154–168)**
+
+Reemplazar el objeto `progress` por:
+
+```ts
+const progress: StudentProgress = {
+  id,
+  coachId,
+  athleteId,
+  athleteName: name,
+  athleteEmail: email || null,
+  ...(phone ? { athletePhone: phone } : {}),
+  level: 1,
+  coachAssessment: 1,
+  lastNote: '',
+  createdAt: now,
+  updatedAt: now,
+}
+```
+
+- [ ] **Step 3: PUT — preservar progreso normalizando legacy (líneas ~226–242)**
+
+Reemplazar el objeto `progress` por:
+
+```ts
+const progress: StudentProgress = {
+  id,
+  coachId,
+  athleteId,
+  athleteName: details.name,
+  athleteEmail: details.email || null,
+  athletePhone: details.phone,
+  athleteAddress: details.address,
+  athleteLocation: details.location,
+  level: normalizeLevelValue(current?.level),
+  coachAssessment: clampScale(current?.coachAssessment, 1),
+  // Firestore rejects `undefined`; only include result when the doc has one.
+  ...(current?.result ? { result: current.result } : {}),
+  lastNote: current?.lastNote || '',
+  createdAt: current?.createdAt || now,
+  updatedAt: now,
+}
+```
+
+- [ ] **Step 4: PATCH — entry con `result`, sin `goal`/`nextFocus` (líneas ~321–332)**
+
+El objeto `progress` del PATCH no cambia (el spread `...normalized` ya trae `level`, `coachAssessment`, `result`, `lastNote`). Reemplazar el objeto `entry` por:
+
+```ts
+const entry: StudentProgressEntry = {
+  id: entryRef.id,
+  coachId,
+  athleteId: body.athleteId,
+  level: normalized.level,
+  coachAssessment: normalized.coachAssessment,
+  result: normalized.result,
+  note: normalized.lastNote,
+  createdAt: now,
+}
+```
+
+- [ ] **Step 5: `app/api/coach/agenda/bookings/route.ts` — default del doc auto-creado (~133–147)**
+
+Reemplazar dentro del objeto `progress`:
+
+```ts
+      level: 1,
+      coachAssessment: 1,
+      lastNote: '',
+```
+
+(eliminando `level: 'Inicial'`, `goal: ''`, `nextFocus: ''`.)
+
+- [ ] **Step 6: Verificar**
+
+Run: `pnpm typecheck`
+Expected: errores restantes SOLO en los 3 archivos de UI (modal, CoachStudents, athlete progress page). Los dos routes ya sin errores.
+
+(Commit al final de Task 4, cuando el typecheck pasa completo. Si se prefiere commit por task, este estado intermedio no compila — por eso lib+API+UI se commitean juntos en Task 4 Step 5.)
+
+---
+
+### Task 3: `StudentProgressModal` — 3 clicks + nota
+
+**Files:**
+- Modify: `components/coach/StudentProgressModal.tsx` (rewrite del contenido del form; shell del dialog/overlay se conserva)
+
+**Interfaces:**
+- Consumes: `PROGRESS_LEVELS`, `PROGRESS_SUBLEVELS`, `PROGRESS_RESULTS` de `CONSTANTS/PROGRESS_SCALE`; `normalizeLevelValue`, `clampScale`, tipos de `lib/coach-student-progress`; `patchAuthed` (sin cambios).
+- Produces: mismo contrato `onSaved(entry, progress)`; PATCH body ahora `{ athleteId, level, coachAssessment, result, lastNote }`.
+
+- [ ] **Step 1: Reescribir el componente**
+
+Contenido completo del archivo:
+
+```tsx
+'use client'
+
+import { useKeyboardSafeArea } from '@comps/hooks/useKeyboardSafeArea'
+import { useState } from 'react'
+import {
+  PROGRESS_LEVELS,
+  PROGRESS_RESULTS,
+  PROGRESS_SUBLEVELS,
+  type ProgressScaleOption,
+} from '@/CONSTANTS/PROGRESS_SCALE'
+import { patchAuthed } from '@/lib/client/authed-api'
+import {
+  clampScale,
+  normalizeLevelValue,
+  type StudentProgress,
+  type StudentProgressEntry,
+} from '@/lib/coach-student-progress'
+import { GENERIC_USER_ERROR, reportInternalError } from '@/lib/user-facing-error'
+
+export default function StudentProgressModal({
+  athleteId,
+  studentName,
+  initial,
+  onClose,
+  onSaved,
+}: {
+  athleteId: string
+  studentName: string
+  initial?: StudentProgress | null
+  onClose: () => void
+  onSaved: (entry: StudentProgressEntry, progress: StudentProgress) => void
+}) {
+  // Level/avance carry the student's current state as a starting point; the
+  // session result starts unselected because it grades this session only.
+  const [level, setLevel] = useState(() => normalizeLevelValue(initial?.level))
+  const [subLevel, setSubLevel] = useState(() => clampScale(initial?.coachAssessment, 1))
+  const [result, setResult] = useState<number | null>(null)
+  const [note, setNote] = useState('')
+  const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle')
+  const keyboardSafeArea = useKeyboardSafeArea()
+
+  async function save() {
+    if (result === null) return
+    setStatus('saving')
+    try {
+      const response = await patchAuthed('/api/coach/students', {
+        athleteId,
+        level,
+        coachAssessment: subLevel,
+        result,
+        lastNote: note,
+      })
+      const payload = (await response.json()) as {
+        progress: StudentProgress
+        entry: StudentProgressEntry
+      }
+      onSaved(payload.entry, payload.progress)
+    } catch (err) {
+      reportInternalError('COACH_STUDENT_PROGRESS_SAVE', err)
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Agregar progreso de ${studentName}`}
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-[rgba(10,37,64,0.55)] p-4 backdrop-blur-sm"
+      style={keyboardSafeArea ? { paddingBottom: `calc(${keyboardSafeArea}px + 1rem)` } : undefined}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose()
+      }}
+    >
+      <div className="flex max-h-[calc(100dvh-2rem)] w-full max-w-lg flex-col gap-4 overflow-y-auto rounded-[var(--r-md)] bg-white p-5 shadow-[var(--shadow-md)]">
+        <div className="mx-auto h-1 w-10 rounded-full bg-(--c-border) sm:hidden" />
+        <div>
+          <h3 className="text-xl font-bold text-(--c-ocean)">Agregar progreso</h3>
+          <p className="mt-0.5 text-sm text-(--c-text-2)">{studentName}</p>
+        </div>
+
+        <ScaleRow
+          label="Nivel"
+          options={PROGRESS_LEVELS}
+          selected={level}
+          onSelect={setLevel}
+        />
+        <ScaleRow
+          label="Avance"
+          options={PROGRESS_SUBLEVELS}
+          selected={subLevel}
+          onSelect={setSubLevel}
+        />
+        <ScaleRow
+          label="Resultado"
+          options={PROGRESS_RESULTS}
+          selected={result}
+          onSelect={setResult}
+        />
+
+        <label className="grid gap-1 text-sm font-semibold text-(--c-ocean)">
+          Nota (opcional)
+          <textarea
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            maxLength={800}
+            rows={2}
+            placeholder="Observaciones de la sesión."
+            className="rounded-[var(--r-sm)] border border-(--c-border) bg-white px-3 py-2 text-sm text-(--c-ocean)"
+          />
+        </label>
+
+        {status === 'error' && (
+          <p className="text-sm text-(--c-error,#b91c1c)">{GENERIC_USER_ERROR}</p>
+        )}
+
+        <div className="mt-1 flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={save}
+            disabled={status === 'saving' || result === null}
+            className="min-h-12 rounded-full bg-(--c-ocean) font-bold text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+          >
+            {status === 'saving' ? 'Guardando…' : 'Guardar progreso'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="min-h-11 rounded-full font-semibold text-(--c-text-2) hover:text-(--c-ocean)"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ScaleRow({
+  label,
+  options,
+  selected,
+  onSelect,
+}: {
+  label: string
+  options: ProgressScaleOption[]
+  selected: number | null
+  onSelect: (value: number) => void
+}) {
+  return (
+    <fieldset className="grid gap-1.5">
+      <legend className="text-sm font-semibold text-(--c-ocean)">{label}</legend>
+      <div role="radiogroup" aria-label={label} className="grid grid-cols-4 gap-2">
+        {options.map((option) => {
+          const active = option.value === selected
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onSelect(option.value)}
+              className={`flex min-h-12 flex-col items-center justify-center rounded-[var(--r-sm)] border text-sm font-bold transition-colors ${
+                active
+                  ? 'border-(--c-ocean) bg-(--c-ocean) text-white'
+                  : 'border-(--c-border) bg-white text-(--c-ocean) hover:bg-(--c-surface)'
+              }`}
+            >
+              {option.emoji ? (
+                <>
+                  <span aria-hidden="true" className="text-xl leading-none">
+                    {option.emoji}
+                  </span>
+                  <span className="mt-0.5 text-[10px] font-semibold">{option.label}</span>
+                </>
+              ) : (
+                option.label
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}
+```
+
+- [ ] **Step 2: Verificar**
+
+Run: `pnpm typecheck`
+Expected: errores restantes SOLO en `CoachStudents.tsx` y `app/(app)/athlete/progress/page.tsx`.
+
+---
+
+### Task 4: Vistas (CoachStudents + página de progreso del alumno) y commit
+
+**Files:**
+- Modify: `components/coach/CoachStudents.tsx` (líneas ~226–228, ~305–316, `EntryItem` ~396–438, eliminar `DetailCol` ~440)
+- Modify: `app/(app)/athlete/progress/page.tsx` (líneas ~37–41, ~101–130, eliminar `ProgressNote` ~206–224)
+
+**Interfaces:**
+- Consumes: `formatStudentLevel`, `clampScale` de lib; `progressResultEmoji` de `CONSTANTS/PROGRESS_SCALE`.
+
+- [ ] **Step 1: `CoachStudents.tsx` — resumen y métrica del card**
+
+Agregar imports:
+
+```ts
+import { progressResultEmoji } from '@/CONSTANTS/PROGRESS_SCALE'
+import {
+  formatStudentLevel,
+  type StudentProgress,
+  type StudentProgressEntry,
+} from '@/lib/coach-student-progress'
+```
+
+Reemplazar líneas ~226–228:
+
+```ts
+const level = student.progress ? formatStudentLevel(student.progress) : '1.1'
+const summary = `${student.totalClasses} ${student.totalClasses === 1 ? 'clase' : 'clases'} · Nivel ${level}`
+```
+
+Reemplazar el segundo `MetricPill` (~311–315):
+
+```tsx
+<MetricPill
+  icon={<FiTrendingUp aria-hidden="true" />}
+  label="Nivel"
+  value={student.progress ? formatStudentLevel(student.progress) : '—'}
+/>
+```
+
+(la variable `assessment` de la línea ~227 queda sin uso — eliminarla.)
+
+- [ ] **Step 2: `CoachStudents.tsx` — `EntryItem` con `3.2 · 😊` y solo nota**
+
+Reemplazar la función `EntryItem` completa (y eliminar `DetailCol`):
+
+```tsx
+function EntryItem({ entry }: { entry: StudentProgressEntry }) {
+  const [open, setOpen] = useState(false)
+  const emoji = progressResultEmoji(entry.result)
+  const date = new Date(entry.createdAt).toLocaleDateString('es-MX', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+
+  return (
+    <li className="rounded-[var(--r-sm)] border border-(--c-border)">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="flex w-full items-start gap-2 p-3 text-left transition-colors hover:bg-(--c-surface)"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm font-bold text-(--c-ocean)">{date}</span>
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-(--c-surface) px-2.5 py-0.5 text-xs font-semibold text-(--c-ocean)">
+              {formatStudentLevel(entry)}
+              {emoji && <span aria-hidden="true">· {emoji}</span>}
+            </span>
+          </div>
+          {entry.note && (
+            <p
+              className={`mt-2 text-sm text-(--c-text-2) ${open ? 'whitespace-pre-wrap' : 'truncate'}`}
+            >
+              {entry.note}
+            </p>
+          )}
+        </div>
+        <FiChevronDown
+          aria-hidden="true"
+          className={`mt-0.5 shrink-0 text-(--c-ocean-mid) transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+    </li>
+  )
+}
+```
+
+- [ ] **Step 3: `app/(app)/athlete/progress/page.tsx` — nivel, promedio /4, sin objetivo/foco**
+
+Imports: quitar `FiTarget` de `react-icons/fi`; agregar:
+
+```ts
+import { progressResultEmoji } from '@/CONSTANTS/PROGRESS_SCALE'
+import {
+  clampScale,
+  formatStudentLevel,
+  type StudentProgress,
+} from '@/lib/coach-student-progress'
+```
+
+Reemplazar `avgAssessment` (~37–41):
+
+```ts
+const avgAssessment = progress.length
+  ? `${Math.round(
+      progress.reduce((total, item) => total + clampScale(item.coachAssessment, 1), 0) /
+        progress.length
+    )}/4`
+  : '—'
+```
+
+En el card del coach (~101–130): reemplazar `Nivel: {item.level}` por `Nivel {formatStudentLevel(item)}`; reemplazar el span del assessment por:
+
+```tsx
+<span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-(--c-surface) px-3 py-1 text-sm font-semibold text-(--c-ocean)">
+  {progressResultEmoji(item.result) || <FiTrendingUp aria-hidden="true" />}
+  {formatStudentLevel(item)}
+</span>
+```
+
+Eliminar el bloque `{(item.goal || item.nextFocus) && (...)}` completo (~108–125) y la función `ProgressNote` (~206–224). El bloque `{item.lastNote && ...}` se queda.
+
+- [ ] **Step 4: Verificar typecheck y lint completos**
+
+Run: `pnpm typecheck && pnpm check`
+Expected: ambos pasan sin errores (biome puede pedir `pnpm format` — correrlo si hace falta).
+
+- [ ] **Step 5: Commit (lib + API + UI juntos — el estado intermedio no compila)**
+
+```bash
+git add CONSTANTS/PROGRESS_SCALE.ts lib/coach-student-progress.ts app/api/coach/students/route.ts app/api/coach/agenda/bookings/route.ts components/coach/StudentProgressModal.tsx components/coach/CoachStudents.tsx "app/(app)/athlete/progress/page.tsx"
+git commit -m "feat: simplify student progress capture to 3-click scale
+
+Level/sub-level become numeric 1-4 (legacy strings mapped on read),
+new result field with emoji scale, goal/nextFocus removed.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Verificación manual del flujo
+
+**Files:** ninguno (verificación).
+
+- [ ] **Step 1: Levantar emulator + dev** según memoria `testing-authed-flows-emulator.md` (login coach vía emulator auth popup).
+
+- [ ] **Step 2: Flujo coach**
+  1. Abrir Alumnos → card de un alumno → "Agregar progreso".
+  2. Confirmar: 3 filas de pills, nivel/avance pre-seleccionados, resultado sin selección, Guardar deshabilitado.
+  3. Elegir resultado → Guardar habilitado → guardar con y sin nota.
+  4. Confirmar entry nuevo en historial con formato `3.2 · 😊` y resumen del card `Nivel 3.2`.
+
+- [ ] **Step 3: Legacy** — con un doc que tenga `level: 'Intermedio'` (seed o editar en emulator UI): card muestra `Nivel 3.x`, modal pre-selecciona nivel 3; tras guardar, el doc queda numérico.
+
+- [ ] **Step 4: Flujo alumno** — login como alumno vinculado: "Mi progreso" muestra `Nivel 3.2`, emoji del último resultado, promedio `n/4`, sin bloques Objetivo/Próximo foco. Entries viejos sin `result` no muestran emoji.
+
+- [ ] **Step 5: Reportar resultados** al usuario (qué se verificó, cualquier hallazgo).

--- a/docs/superpowers/specs/2026-07-17-simplified-student-progress-design.md
+++ b/docs/superpowers/specs/2026-07-17-simplified-student-progress-design.md
@@ -128,6 +128,15 @@ genérico en español (estándar del repo).
   como 3.
 - E2e existente que toque progreso (si hay) se actualiza.
 
+## Addendum (2026-07-18): nivel = promedio de últimas 5 sesiones
+
+El `level`/`coachAssessment` del doc `StudentProgress` NO es el último click:
+al guardar, el PATCH recalcula la posición como el promedio de las últimas 5
+entries (incluida la nueva) sobre la escala combinada 1–16
+(`(nivel−1)·4 + avance`), redondeado hacia arriba (`Math.ceil`), y lo convierte
+de vuelta a `nivel.avance`. La entry sí conserva los valores clickeados.
+Implementado en `computeStudentPosition` (`lib/coach-student-progress.ts`).
+
 ## Out of scope
 
 - Personalización por coach de la escala.

--- a/docs/superpowers/specs/2026-07-17-simplified-student-progress-design.md
+++ b/docs/superpowers/specs/2026-07-17-simplified-student-progress-design.md
@@ -1,0 +1,135 @@
+# Simplified student progress capture — design
+
+Date: 2026-07-17
+Status: approved (pending spec review)
+
+## Goal
+
+Registrar el progreso de un alumno debe tomar **3 clicks + guardar**, con una nota
+de texto opcional. Se elimina el formulario actual de 5 campos.
+
+Las tres dimensiones (por ahora numéricas, en el futuro con títulos e iconos
+configurables):
+
+| Dimensión  | Valores | Semántica                                          |
+| ---------- | ------- | -------------------------------------------------- |
+| Nivel      | 1–4     | Etapa del alumno                                   |
+| Avance     | 1–4     | Subnivel dentro del nivel (nivel 3 + avance 2 = 3.2) |
+| Resultado  | 1–4     | Resultado de la sesión: 😢 triste, 😠 enojado, 😐 neutro, 😊 feliz |
+
+## Decisions (approved)
+
+- **Campos viejos:** `goal` y `nextFocus` se eliminan del modal, de los tipos de
+  input y del normalizador. Quedan huérfanos en docs viejos de Firestore
+  (ignorados). Niveles string viejos se migran por mapeo en lectura.
+- **Avance = subnivel** del nivel, no métrica independiente.
+- **Config global:** la escala (labels, emojis) vive en `CONSTANTS/`; no hay
+  personalización por coach todavía.
+- **Nombre de campo persistido:** se mantiene `coachAssessment` en Firestore y en
+  los tipos para el subnivel. Sin renombre de campo.
+
+## Data model
+
+`lib/coach-student-progress.ts`:
+
+- `level: number` (1–4) — reemplaza el union de strings. `STUDENT_LEVELS` (los 5
+  strings) desaparece de la API pública; queda solo un mapa interno de migración:
+  `Inicial→1, Básico→2, Intermedio→3, Avanzado→4, Competitivo→4`.
+- `coachAssessment: number` (1–4) — subnivel. Antes 1–5; el clamp pasa a máx 4.
+- `result: number` (1–4) — **nuevo**, en `StudentProgressEntry` y como último
+  resultado en `StudentProgress`.
+- `note`/`lastNote`: sin cambios (opcional, máx 800).
+- `goal`, `nextFocus`: se eliminan de `StudentProgress`, `StudentProgressEntry`,
+  `StudentProgressInput` y `normalizeStudentProgressInput`.
+- `normalizeStudentProgressInput`: acepta `level` como número o string legacy
+  (aplica el mapa), clamp 1–4; clamp `coachAssessment` 1–4; valida `result` 1–4
+  (default 3 = neutro si falta/ inválido).
+- Normalización en lectura: donde se lea un `StudentProgress` con `level` string
+  (docs viejos), se pasa por el mismo mapa antes de mostrar. Sin script de
+  migración; los docs se corrigen al siguiente guardado.
+
+## Scale constants
+
+Nuevo `CONSTANTS/PROGRESS_SCALE.ts`:
+
+```ts
+export const PROGRESS_LEVELS = [
+  { value: 1, label: '1' },
+  { value: 2, label: '2' },
+  { value: 3, label: '3' },
+  { value: 4, label: '4' },
+]
+export const PROGRESS_SUBLEVELS = [ /* idem 1–4 */ ]
+export const PROGRESS_RESULTS = [
+  { value: 1, label: 'Triste', emoji: '😢' },
+  { value: 2, label: 'Enojado', emoji: '😠' },
+  { value: 3, label: 'Neutro', emoji: '😐' },
+  { value: 4, label: 'Feliz', emoji: '😊' },
+]
+```
+
+Cambiar títulos/iconos en el futuro = editar este archivo. La UI solo consume
+estas constantes, nunca hardcodea valores.
+
+## UI — `StudentProgressModal`
+
+Tres filas de botones tipo pill (min-h-12, táctiles):
+
+```
+Nivel      [1] [2] [3] [4]
+Avance     [1] [2] [3] [4]
+Resultado  [😢] [😠] [😐] [😊]   (label pequeño debajo de cada emoji)
+
+Nota (opcional)  [textarea compacta]
+
+[Guardar progreso]
+[Cancelar]
+```
+
+- Pre-selección: `level` y `coachAssessment` actuales del alumno (con mapeo
+  legacy si vienen como string). `result` inicia **sin selección** — es la
+  evaluación de esta sesión.
+- Guardar deshabilitado hasta elegir Resultado.
+- Se eliminan: select de nivel, input numérico de avance, inputs de objetivo y
+  próximo foco.
+- Botones seleccionados: fondo `--c-ocean`, texto blanco; no seleccionados:
+  borde `--c-border`. Accesible: `role="radiogroup"` por fila, `aria-checked`.
+
+## API
+
+- `PATCH /api/coach/students` (`route.ts:326`): pasa `result` al entry y al doc;
+  defaults nuevos (`level: 1`, `coachAssessment: 1`); deja de escribir
+  `goal`/`nextFocus`.
+- `app/api/coach/agenda/bookings/route.ts:140`: default `level: 'Inicial'` →
+  `level: 1`.
+- `GET /api/athlete/progress`: sin cambios estructurales; sirve los entries con
+  los campos nuevos.
+
+## Views
+
+- `app/(app)/athlete/progress/page.tsx`: mostrar `Nivel 3.2` (nivel.avance),
+  emoji de resultado por entry; el promedio `coachAssessment/5` pasa a `/4`.
+- `components/coach/CoachStudents.tsx` (líneas 226–228, 416): resumen
+  `Nivel 3.2`; historial `3.2 · 😊` usando `PROGRESS_SCALE`.
+- Cualquier lectura de `level` aplica el mapeo legacy antes de renderizar.
+- Entries viejos sin `result`: no se renderiza emoji (campo ausente ≠ neutro).
+
+## Error handling
+
+Sin cambios de patrón: errores de guardado → `reportInternalError` + mensaje
+genérico en español (estándar del repo).
+
+## Testing
+
+- `pnpm typecheck` + `pnpm check`.
+- Verificación manual del flujo (emulator, login coach): abrir modal, 3 clicks,
+  guardar, ver el entry en historial coach y en la vista del alumno; comprobar
+  que un alumno con `level: 'Intermedio'` viejo se muestra y pre-selecciona
+  como 3.
+- E2e existente que toque progreso (si hay) se actualiza.
+
+## Out of scope
+
+- Personalización por coach de la escala.
+- Script de migración de datos (mapeo en lectura lo cubre).
+- Iconos/logos custom (solo emoji por ahora).

--- a/lib/coach-student-progress.ts
+++ b/lib/coach-student-progress.ts
@@ -66,6 +66,26 @@ export function formatStudentLevel(item: { level: unknown; coachAssessment: unkn
   return `${normalizeLevelValue(item.level)}.${clampScale(item.coachAssessment, 1)}`
 }
 
+/**
+ * Student position derived from the most recent entries: average of the last
+ * `window` entries on the combined 1-16 scale ((level-1)*4 + subLevel),
+ * rounded up so recent good sessions pull the level upward.
+ */
+export function computeStudentPosition(
+  entries: Array<Pick<StudentProgressEntry, 'level' | 'coachAssessment' | 'createdAt'>>,
+  window = 5
+) {
+  const recent = [...entries].sort((a, b) => b.createdAt - a.createdAt).slice(0, window)
+  if (recent.length === 0) return { level: 1, coachAssessment: 1 }
+  const total = recent.reduce(
+    (sum, entry) =>
+      sum + (normalizeLevelValue(entry.level) - 1) * 4 + clampScale(entry.coachAssessment, 1),
+    0
+  )
+  const score = Math.ceil(total / recent.length)
+  return { level: Math.floor((score - 1) / 4) + 1, coachAssessment: ((score - 1) % 4) + 1 }
+}
+
 export function normalizeStudentProgressInput(input: StudentProgressInput) {
   return {
     level: normalizeLevelValue(input.level),

--- a/lib/coach-student-progress.ts
+++ b/lib/coach-student-progress.ts
@@ -1,12 +1,11 @@
-export const STUDENT_LEVELS = [
-  'Inicial',
-  'Básico',
-  'Intermedio',
-  'Avanzado',
-  'Competitivo',
-] as const
-
-export type StudentLevel = (typeof STUDENT_LEVELS)[number]
+/** Legacy string levels stored before the numeric 1-4 scale. */
+const LEGACY_LEVEL_MAP: Record<string, number> = {
+  Inicial: 1,
+  Básico: 2,
+  Intermedio: 3,
+  Avanzado: 4,
+  Competitivo: 4,
+}
 
 export interface StudentProgress {
   id: string
@@ -17,28 +16,32 @@ export interface StudentProgress {
   athletePhone?: string
   athleteAddress?: string
   athleteLocation?: string
-  level: StudentLevel
-  goal: string
-  lastNote: string
-  nextFocus: string
+  /** 1-4. Legacy docs may still hold a string; normalize with normalizeLevelValue. */
+  level: number
+  /** Sub-level 1-4 (field name kept for data compatibility). */
   coachAssessment: number
+  /** Last session result 1-4; absent on docs saved before this field existed. */
+  result?: number
+  lastNote: string
   createdAt: number
   updatedAt: number
 }
 
-export type StudentProgressInput = Partial<
-  Pick<StudentProgress, 'level' | 'goal' | 'lastNote' | 'nextFocus' | 'coachAssessment'>
->
+export interface StudentProgressInput {
+  level?: unknown
+  coachAssessment?: unknown
+  result?: unknown
+  lastNote?: unknown
+}
 
 /** One timestamped progress record in a student's history. */
 export interface StudentProgressEntry {
   id: string
   coachId: string
   athleteId: string
-  level: StudentLevel
+  level: number
   coachAssessment: number
-  goal: string
-  nextFocus: string
+  result?: number
   note: string
   createdAt: number
 }
@@ -47,26 +50,31 @@ export function studentProgressId(coachId: string, athleteId: string) {
   return `${coachId}_${athleteId}`
 }
 
-export function normalizeStudentProgressInput(input: StudentProgressInput) {
-  const level = STUDENT_LEVELS.includes(input.level as StudentLevel)
-    ? (input.level as StudentLevel)
-    : 'Inicial'
+export function clampScale(value: unknown, fallback: number) {
+  const score = Number(value)
+  if (!Number.isFinite(score)) return fallback
+  return Math.min(4, Math.max(1, Math.round(score)))
+}
 
+export function normalizeLevelValue(value: unknown): number {
+  if (typeof value === 'string' && value in LEGACY_LEVEL_MAP) return LEGACY_LEVEL_MAP[value]
+  return clampScale(value, 1)
+}
+
+/** Renders the combined position, e.g. level 3 + sub-level 2 -> "3.2". */
+export function formatStudentLevel(item: { level: unknown; coachAssessment: unknown }) {
+  return `${normalizeLevelValue(item.level)}.${clampScale(item.coachAssessment, 1)}`
+}
+
+export function normalizeStudentProgressInput(input: StudentProgressInput) {
   return {
-    level,
-    goal: limitText(input.goal, 240),
+    level: normalizeLevelValue(input.level),
+    coachAssessment: clampScale(input.coachAssessment, 1),
+    result: clampScale(input.result, 3),
     lastNote: limitText(input.lastNote, 800),
-    nextFocus: limitText(input.nextFocus, 240),
-    coachAssessment: clampScore(input.coachAssessment),
   }
 }
 
 function limitText(value: unknown, max: number) {
   return typeof value === 'string' ? value.trim().slice(0, max) : ''
-}
-
-function clampScore(value: unknown) {
-  const score = Number(value)
-  if (!Number.isFinite(score)) return 1
-  return Math.min(5, Math.max(1, Math.round(score)))
 }


### PR DESCRIPTION
## Summary
- Replaces the 5-field progress form with a 3-click capture: **Nivel 1–4**, **Avance 1–4** (sub-level), **Resultado** (😢😠😐😊) + optional note.
- `level` becomes numeric; legacy string levels (`Inicial`…`Competitivo`) are mapped on read (`Inicial→1, Básico→2, Intermedio→3, Avanzado/Competitivo→4`) and migrate to numbers on the next save — no migration script.
- New `result` field (1–4) per entry; old entries without it render no emoji. `goal`/`nextFocus` removed from types, modal, and normalizer (orphaned in old docs, ignored).
- Student level shown everywhere is now the **rounded-up average of the last 5 entries** on the combined 1–16 scale, computed server-side on save (`computeStudentPosition`); entries keep the coach's clicked values.
- Scale labels/emojis centralized in `CONSTANTS/PROGRESS_SCALE.ts` for future custom titles/icons.
- Persisted sub-level field name stays `coachAssessment` for data compatibility.

## Verification
- `pnpm typecheck` clean; Biome clean on all touched files.
- Manually verified against the Firebase emulator: 3-click modal (save blocked until Resultado), legacy `'Intermedio'` doc renders `3.x` and pre-selects, legacy entry without `result` shows no emoji, doc migrates to numeric on save, athlete view shows `Nivel n.n` + emoji + `/4` average, average-level math confirmed (entries [4.4, 1.3, 3.1, 2.2, 2.1] → card `2.4`).
- Independent per-task and whole-branch code reviews: no Critical/Important findings.

## Follow-up (known, non-blocking)
- ScaleRow radiogroup lacks roving tabindex/arrow-key navigation (fully operable via Tab + Enter/Space).

Spec: `docs/superpowers/specs/2026-07-17-simplified-student-progress-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)